### PR TITLE
feat(YfmNote, YfmCut): easy removal by pressing the backspace button

### DIFF
--- a/src/extensions/yfm/YfmCut/commands.test.ts
+++ b/src/extensions/yfm/YfmCut/commands.test.ts
@@ -2,9 +2,10 @@ import {Schema} from 'prosemirror-model';
 import {EditorView} from 'prosemirror-view';
 import {EditorState, TextSelection} from 'prosemirror-state';
 import {builders} from 'prosemirror-test-builder';
+
 import {CutNode} from './const';
 import {getSpec} from './spec';
-import {removeCut} from './commands';
+import {backToCutTitle, removeCut} from './commands';
 
 const schema = new Schema({
     nodes: {
@@ -26,7 +27,7 @@ const {
     yfm_cut: cut,
     yfm_cut_title: cutTitle,
     yfm_cut_content: cutContent,
-} = builders(schema, {}) as PMTestBuilderResult<
+} = builders(schema) as PMTestBuilderResult<
     'doc' | 'paragraph' | CutNode.Cut | CutNode.CutTitle | CutNode.CutContent
 >;
 
@@ -44,5 +45,20 @@ describe('YfmCut commands', () => {
         expect(res).toBe(true);
         expect(view.state.doc).toMatchNode(doc(p('cut title'), p('cut content in paragraph')));
         expect((view.state.selection as TextSelection).$cursor?.pos).toBe(1);
+    });
+
+    it("backToCutTitle: should move cursor to the end of cut's title", () => {
+        const pmDoc = doc(cut(cutTitle('cut title'), cutContent(p('cut content in paragraph'))));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                schema,
+                doc: pmDoc,
+                selection: TextSelection.create(pmDoc, 14),
+            }),
+        });
+        const res = backToCutTitle(view.state, view.dispatch, view);
+        expect(res).toBe(true);
+        expect(view.state.doc).toMatchNode(pmDoc);
+        expect((view.state.selection as TextSelection).$cursor?.pos).toBe(11);
     });
 });

--- a/src/extensions/yfm/YfmCut/commands.test.ts
+++ b/src/extensions/yfm/YfmCut/commands.test.ts
@@ -1,0 +1,48 @@
+import {Schema} from 'prosemirror-model';
+import {EditorView} from 'prosemirror-view';
+import {EditorState, TextSelection} from 'prosemirror-state';
+import {builders} from 'prosemirror-test-builder';
+import {CutNode} from './const';
+import {getSpec} from './spec';
+import {removeCut} from './commands';
+
+const schema = new Schema({
+    nodes: {
+        doc: {content: 'block+'},
+        text: {group: 'inline'},
+        paragraph: {
+            group: 'block',
+            content: 'inline*',
+            parseDOM: [{tag: 'p'}],
+            toDOM: () => ['p', 0],
+        },
+        ...getSpec(),
+    },
+});
+
+const {
+    doc,
+    paragraph: p,
+    yfm_cut: cut,
+    yfm_cut_title: cutTitle,
+    yfm_cut_content: cutContent,
+} = builders(schema, {}) as PMTestBuilderResult<
+    'doc' | 'paragraph' | CutNode.Cut | CutNode.CutTitle | CutNode.CutContent
+>;
+
+describe('YfmCut commands', () => {
+    it('removeCut: should replace cut with its content', () => {
+        const pmDoc = doc(cut(cutTitle('cut title'), cutContent(p('cut content in paragraph'))));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                schema,
+                doc: pmDoc,
+                selection: TextSelection.create(pmDoc, 2),
+            }),
+        });
+        const res = removeCut(view.state, view.dispatch, view);
+        expect(res).toBe(true);
+        expect(view.state.doc).toMatchNode(doc(p('cut title'), p('cut content in paragraph')));
+        expect((view.state.selection as TextSelection).$cursor?.pos).toBe(1);
+    });
+});

--- a/src/extensions/yfm/YfmCut/index.ts
+++ b/src/extensions/yfm/YfmCut/index.ts
@@ -8,7 +8,7 @@ import {CutNode, cutType} from './const';
 import {fromYfm} from './fromYfm';
 import {getSpec, YfmCutSpecOptions} from './spec';
 import {createYfmCut, toYfmCut} from './actions/toYfmCut';
-import {exitFromCutTitle, liftEmptyBlockFromCut, removeCut} from './commands';
+import {backToCutTitle, exitFromCutTitle, liftEmptyBlockFromCut, removeCut} from './commands';
 
 const cutAction = 'toYfmCut';
 
@@ -53,7 +53,7 @@ export const YfmCut: ExtensionAuto<YfmCutOptions> = (builder, opts) => {
         }))
         .addAction(cutAction, () => toYfmCut)
         .addKeymap(() => ({
-            Backspace: chainCommands(removeCut),
+            Backspace: chainCommands(backToCutTitle, removeCut),
             Enter: chainCommands(exitFromCutTitle, liftEmptyBlockFromCut),
         }))
         .addInputRules(({schema}) => ({

--- a/src/extensions/yfm/YfmCut/index.ts
+++ b/src/extensions/yfm/YfmCut/index.ts
@@ -8,7 +8,7 @@ import {CutNode, cutType} from './const';
 import {fromYfm} from './fromYfm';
 import {getSpec, YfmCutSpecOptions} from './spec';
 import {createYfmCut, toYfmCut} from './actions/toYfmCut';
-import {exitFromCutTitle, liftEmptyBlockFromCut} from './commands';
+import {exitFromCutTitle, liftEmptyBlockFromCut, removeCut} from './commands';
 
 const cutAction = 'toYfmCut';
 
@@ -53,6 +53,7 @@ export const YfmCut: ExtensionAuto<YfmCutOptions> = (builder, opts) => {
         }))
         .addAction(cutAction, () => toYfmCut)
         .addKeymap(() => ({
+            Backspace: chainCommands(removeCut),
             Enter: chainCommands(exitFromCutTitle, liftEmptyBlockFromCut),
         }))
         .addInputRules(({schema}) => ({

--- a/src/extensions/yfm/YfmNote/commands.test.ts
+++ b/src/extensions/yfm/YfmNote/commands.test.ts
@@ -5,7 +5,7 @@ import {builders} from 'prosemirror-test-builder';
 
 import {NoteNode} from './const';
 import {getSpec} from './spec';
-import {removeNote} from './commands';
+import {backToNoteTitle, removeNote} from './commands';
 
 const schema = new Schema({
     nodes: {
@@ -14,7 +14,6 @@ const schema = new Schema({
         paragraph: {
             group: 'block',
             content: 'inline*',
-            parseDOM: [{tag: 'p'}],
             toDOM: () => ['p', 0],
         },
         ...getSpec(),
@@ -44,5 +43,20 @@ describe('YfmNote commands', () => {
         expect(res).toBe(true);
         expect(view.state.doc).toMatchNode(doc(p('note title'), p('note content in paragraph')));
         expect((view.state.selection as TextSelection).$cursor?.pos).toBe(1);
+    });
+
+    it("backToNoteTitle: should move cursor to the end of note's title", () => {
+        const pmDoc = doc(note(noteTitle('note title'), p('note content in paragraph')));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                schema,
+                doc: pmDoc,
+                selection: TextSelection.create(pmDoc, 14),
+            }),
+        });
+        const res = backToNoteTitle(view.state, view.dispatch, view);
+        expect(res).toBe(true);
+        expect(view.state.doc).toMatchNode(pmDoc);
+        expect((view.state.selection as TextSelection).$cursor?.pos).toBe(12);
     });
 });

--- a/src/extensions/yfm/YfmNote/commands.test.ts
+++ b/src/extensions/yfm/YfmNote/commands.test.ts
@@ -1,0 +1,48 @@
+import {Schema} from 'prosemirror-model';
+import {EditorView} from 'prosemirror-view';
+import {EditorState, TextSelection} from 'prosemirror-state';
+import {builders} from 'prosemirror-test-builder';
+
+import {NoteNode} from './const';
+import {getSpec} from './spec';
+import {removeNote} from './commands';
+
+const schema = new Schema({
+    nodes: {
+        doc: {content: 'block+'},
+        text: {group: 'inline'},
+        paragraph: {
+            group: 'block',
+            content: 'inline*',
+            parseDOM: [{tag: 'p'}],
+            toDOM: () => ['p', 0],
+        },
+        ...getSpec(),
+    },
+});
+
+const {
+    doc,
+    paragraph: p,
+    yfm_note: note,
+    yfm_note_title: noteTitle,
+} = builders(schema) as PMTestBuilderResult<
+    'doc' | 'paragraph' | NoteNode.Note | NoteNode.NoteTitle
+>;
+
+describe('YfmNote commands', () => {
+    it('removeNote: should replace note with its content', () => {
+        const pmDoc = doc(note(noteTitle('note title'), p('note content in paragraph')));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                schema,
+                doc: pmDoc,
+                selection: TextSelection.create(pmDoc, 2),
+            }),
+        });
+        const res = removeNote(view.state, view.dispatch, view);
+        expect(res).toBe(true);
+        expect(view.state.doc).toMatchNode(doc(p('note title'), p('note content in paragraph')));
+        expect((view.state.selection as TextSelection).$cursor?.pos).toBe(1);
+    });
+});

--- a/src/extensions/yfm/YfmNote/commands.ts
+++ b/src/extensions/yfm/YfmNote/commands.ts
@@ -1,6 +1,7 @@
 import {Fragment, Node} from 'prosemirror-model';
 import type {Command} from 'prosemirror-state';
 import {TextSelection} from 'prosemirror-state';
+import {pType} from '../../base';
 import {isSameNodeType} from '../../../utils/schema';
 import {isTextSelection} from '../../../utils/selection';
 import {findFirstTextblockChild} from '../../../utils/nodes';
@@ -34,3 +35,36 @@ function getNoteContent(noteNode: Node): Fragment {
     // first child node is note title
     return Fragment.from(noteChildren.slice(1));
 }
+
+/**
+ * Deletes the note if the cursor is at the beginning of the title.
+ * Note will be replaced with his title converted to paragraph and his content.
+ */
+export const removeNote: Command = (state, dispatch, view) => {
+    const {selection, schema} = state;
+    if (!isTextSelection(selection)) return false;
+    const {$cursor} = selection;
+    if (!$cursor) return false;
+    if (
+        !isSameNodeType($cursor.parent, noteTitleType(schema)) ||
+        !isSameNodeType($cursor.node(-1), noteType(schema))
+    ) {
+        return false;
+    }
+    if (view?.endOfTextblock('backward', state)) {
+        if (dispatch) {
+            const noteTitleNode = $cursor.parent;
+            const noteNode = $cursor.node(-1);
+            const content = noteNode.content.replaceChild(
+                0,
+                pType(schema).create(null, noteTitleNode.content),
+            );
+            const from = $cursor.before(-1);
+            const to = from + noteNode.nodeSize;
+            const tr = state.tr.replaceWith(from, to, content);
+            dispatch(tr.setSelection(TextSelection.create(tr.doc, from + 1)));
+        }
+        return true;
+    }
+    return false;
+};

--- a/src/extensions/yfm/YfmNote/commands.ts
+++ b/src/extensions/yfm/YfmNote/commands.ts
@@ -68,3 +68,34 @@ export const removeNote: Command = (state, dispatch, view) => {
     }
     return false;
 };
+
+/**
+ * If the cursor is at the beginning of the first paragraph in note's content,
+ * moves the cursor to the end of the note's title.
+ */
+export const backToNoteTitle: Command = (state, dispatch, view) => {
+    const {selection, schema} = state;
+    if (!isTextSelection(selection)) return false;
+    const {$cursor} = selection;
+    if (!$cursor) return false;
+    if (
+        !isSameNodeType($cursor.parent, pType(schema)) ||
+        !isSameNodeType($cursor.node(-1), noteType(schema))
+    ) {
+        return false;
+    }
+    const noteNode = $cursor.node(-1);
+    if ($cursor.parent !== noteNode.maybeChild(1)) return false;
+    if (view?.endOfTextblock('backward', state)) {
+        if (dispatch) {
+            const noteTitleNode = noteNode.firstChild!;
+            dispatch(
+                state.tr.setSelection(
+                    TextSelection.create(state.doc, $cursor.before(-1) + noteTitleNode.nodeSize),
+                ),
+            );
+        }
+        return true;
+    }
+    return false;
+};

--- a/src/extensions/yfm/YfmNote/index.ts
+++ b/src/extensions/yfm/YfmNote/index.ts
@@ -1,5 +1,6 @@
 import log from '@doc-tools/transform/lib/log';
 import yfmPlugin from '@doc-tools/transform/lib/plugins/notes';
+import {chainCommands} from 'prosemirror-commands';
 import {Action, createExtension, ExtensionAuto} from '../../../core';
 import {toYfm} from './toYfm';
 import {NoteNode} from './const';
@@ -7,7 +8,7 @@ import {fromYfm} from './fromYfm';
 import {getSpec, YfmNoteSpecOptions} from './spec';
 import {createYfmNote, toYfmNote} from './actions/toYfmNote';
 import {nodeInputRule} from '../../../utils/inputrules';
-import {exitFromNoteTitle} from './commands';
+import {exitFromNoteTitle, removeNote} from './commands';
 import {noteType} from './utils';
 
 import './index.scss';
@@ -39,7 +40,10 @@ export const YfmNote: ExtensionAuto<YfmNoteOptions> = (builder, opts) => {
                 tokenSpec: fromYfm[NoteNode.NoteTitle],
             },
         }))
-        .addKeymap(() => ({Enter: exitFromNoteTitle}))
+        .addKeymap(() => ({
+            Enter: exitFromNoteTitle,
+            Backspace: chainCommands(removeNote),
+        }))
         .addAction(noteAction, () => toYfmNote)
         .addInputRules(({schema}) => ({
             rules: [nodeInputRule(/(?:^)({% note)\s$/, noteType(schema).createAndFill(), 1)],

--- a/src/extensions/yfm/YfmNote/index.ts
+++ b/src/extensions/yfm/YfmNote/index.ts
@@ -8,7 +8,7 @@ import {fromYfm} from './fromYfm';
 import {getSpec, YfmNoteSpecOptions} from './spec';
 import {createYfmNote, toYfmNote} from './actions/toYfmNote';
 import {nodeInputRule} from '../../../utils/inputrules';
-import {exitFromNoteTitle, removeNote} from './commands';
+import {backToNoteTitle, exitFromNoteTitle, removeNote} from './commands';
 import {noteType} from './utils';
 
 import './index.scss';
@@ -42,7 +42,7 @@ export const YfmNote: ExtensionAuto<YfmNoteOptions> = (builder, opts) => {
         }))
         .addKeymap(() => ({
             Enter: exitFromNoteTitle,
-            Backspace: chainCommands(removeNote),
+            Backspace: chainCommands(backToNoteTitle, removeNote),
         }))
         .addAction(noteAction, () => toYfmNote)
         .addInputRules(({schema}) => ({


### PR DESCRIPTION
For both note and cut:
- when the cursor is at the beginning of title and you press the backspace button, the block will be replaced by its title and content
- when the cursor is at the beginning of the block content and you press the backspace button, the cursor will be moved to the end of block title