### PR TITLE
feat(core): add context to extension builder

### DIFF
--- a/src/core/ExtensionBuilder.ts
+++ b/src/core/ExtensionBuilder.ts
@@ -38,7 +38,24 @@ enum PluginPriority {
 
 const DEFAULT_PRIORITY = PluginPriority.Medium;
 
+type BuilderContext<T extends object> = {
+    has(key: keyof T): boolean;
+    get<K extends keyof T>(key: K): T[K] | undefined;
+    set<K extends keyof T>(key: K, value: T[K]): BuilderContext<T>;
+};
+
+declare global {
+    namespace YfmEditor {
+        interface Context {}
+    }
+}
+
 export class ExtensionBuilder {
+    static createContext(): BuilderContext<YfmEditor.Context> {
+        return new Map();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     static readonly PluginPriority = PluginPriority;
     readonly PluginPriority = ExtensionBuilder.PluginPriority;
 
@@ -47,6 +64,12 @@ export class ExtensionBuilder {
     #markSpecs: [string, AddPmMarkCallback][] = [];
     #plugins: {cb: AddPmPluginCallback; priority: number}[] = [];
     #actions: [string, AddActionCallback][] = [];
+
+    readonly context: BuilderContext<YfmEditor.Context>;
+
+    constructor(context?: BuilderContext<YfmEditor.Context>) {
+        this.context = context ?? ExtensionBuilder.createContext();
+    }
 
     use(extension: Extension): this;
     use<T>(extension: ExtensionWithOptions<T>, options: T): this;

--- a/src/extensions/markdown/Html/index.ts
+++ b/src/extensions/markdown/Html/index.ts
@@ -1,3 +1,4 @@
+import {logger} from '../../../logger';
 import {createExtension, ExtensionAuto} from '../../../core';
 import {HtmlNode} from './const';
 import {fromYfm} from './fromYfm';
@@ -5,6 +6,11 @@ import {spec} from './spec';
 import {toYfm} from './toYfm';
 
 export const Html: ExtensionAuto = (builder) => {
+    if (builder.context.has('html') && builder.context.get('html') === false) {
+        logger.info('[HTML extension]: Skip extension, because HTML disabled via context');
+        return;
+    }
+
     builder.addNode(HtmlNode.Block, () => ({
         spec: spec[HtmlNode.Block],
         fromYfm: {tokenSpec: fromYfm[HtmlNode.Block]},
@@ -24,3 +30,14 @@ export const Html: ExtensionAuto = (builder) => {
  * Remove after WIKI-16660
  */
 export const HtmlE = createExtension((b, o = {}) => b.use(Html, o));
+
+declare global {
+    namespace YfmEditor {
+        interface Context {
+            /**
+             * Same as @type {MarkdownIt.Options.html}
+             */
+            html: boolean;
+        }
+    }
+}


### PR DESCRIPTION
The key-value storage `context` has been added to the ExtensionBuilder, which allows you to transfer data between extensions.

Usage:
```ts
const builder = new ExtensionBuilder(
  ExtensionBuilder.createContext()
    .set('globalflag', true)
);

const Extension0: ExtensionAuto = (builder) => {
  builder.context.set('someflag', true);
  // ...
};

const Extension1: ExtensionAuto = (builder) => {
  if (builder.context.get('globalflag') === true) {
    // ...
  }
  if (builder.context.get('someflag') === true) {
    // ...
  }
};

builder.use(Extension0).use(Extension1);
```