### PR TITLE
fix(core): when appending replace last empty paragraph with new content and add empty paragraph after

### DIFF
--- a/demo/Playground.scss
+++ b/demo/Playground.scss
@@ -21,6 +21,16 @@
         bottom: 0;
     }
 
+    &__controls {
+        display: flex;
+        align-items: center;
+        column-gap: 8px;
+
+        & > p {
+            margin: 0;
+        }
+    }
+
     &__markup {
         background-color: var(--yc-color-base-generic);
     }

--- a/demo/Playground.tsx
+++ b/demo/Playground.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import block from 'bem-cn-lite';
-import {RadioButton, TextInput} from '@gravity-ui/uikit';
+import {Button, RadioButton, TextInput} from '@gravity-ui/uikit';
 
 import {
     BasePreset,
@@ -88,6 +88,64 @@ export const Playground = React.memo<PlaygroundProps>((props) => {
                     </RadioButton>
                 </span>
             </div>
+            <div className={b('controls')}>
+                <p>isEmpty: {String(editor.isEmpty())}</p>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.clear();
+                        editor.focus();
+                    }}
+                >
+                    Clear
+                </Button>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.append('> append');
+                        editor.focus();
+                    }}
+                >
+                    Append
+                </Button>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.prepend('> prepend');
+                        editor.focus();
+                    }}
+                >
+                    Prepend
+                </Button>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.replace('> replace');
+                        editor.focus();
+                    }}
+                >
+                    Replace
+                </Button>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.moveCursor('start');
+                        editor.focus();
+                    }}
+                >
+                    Move cursor to start
+                </Button>
+                <Button
+                    size="s"
+                    onClick={() => {
+                        editor.moveCursor('end');
+                        editor.focus();
+                    }}
+                >
+                    Move cursor to end
+                </Button>
+            </div>
+            <hr />
             <div className={b('editor')}>
                 <YfmEditorComponent editor={editor} autofocus className={b('editor')} />
             </div>

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -4,7 +4,7 @@ export interface CommonEditor extends ContentHandler {
     focus(): void;
     hasFocus(): boolean;
     getValue(): MarkupString;
-    isEmpty(): boolean;
+    isEmpty(): boolean; // TODO[major]: move isEmpty() to ContentHandler interface
 }
 
 export interface ContentHandler {

--- a/src/core/ContentHandler.test.ts
+++ b/src/core/ContentHandler.test.ts
@@ -1,0 +1,155 @@
+import {Schema} from 'prosemirror-model';
+import {EditorView} from 'prosemirror-view';
+import {EditorState, TextSelection} from 'prosemirror-state';
+import {builders} from 'prosemirror-test-builder';
+import {get$Cursor} from '../utils/selection';
+import {WysiwygContentHandler} from './ContentHandler';
+import type {Parser} from './types/parser';
+
+const schema = new Schema({
+    nodes: {
+        doc: {content: 'block+'},
+        text: {group: 'inline'},
+        paragraph: {group: 'block', content: 'text*', toDOM: () => ['p', 0]},
+    },
+    marks: {},
+});
+
+const {doc, p} = builders(schema, {
+    p: {nodeType: 'paragraph'},
+}) as PMTestBuilderResult<'doc' | 'p'>;
+
+const fakeParser: Parser = {
+    parse(markup) {
+        return doc(p(markup));
+    },
+    validateLink(_url: string): boolean {
+        throw new Error('Function not implemented.');
+    },
+    normalizeLink(_url: string): string {
+        throw new Error('Function not implemented.');
+    },
+    normalizeLinkText(_url: string): string {
+        throw new Error('Function not implemented.');
+    },
+};
+
+describe('WysiwygContentHandler', () => {
+    it('should clear the document', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('first line'), p('second line')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.clear();
+        expect(view.state.doc).toMatchNode(doc(p()));
+    });
+
+    it('should append markup to empty document', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p()),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.append('appended');
+        expect(view.state.doc).toMatchNode(doc(p('appended'), p()));
+        expect(get$Cursor(view.state.selection)?.pos).toBe(
+            view.state.doc.nodeSize - 3, // cursor should be in last empty para
+        );
+    });
+
+    it('should append markup to not empty document', () => {
+        const document = doc(p('content'));
+        const pos = 7;
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, pos),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.append('appended');
+        expect(view.state.doc).toMatchNode(doc(p('content'), p('appended'), p()));
+        // the cursor should not move
+        expect(get$Cursor(view.state.selection)?.pos).toBe(pos);
+    });
+
+    it('should prepend markup to empty document', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p()),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.prepend('prepended');
+        expect(view.state.doc).toMatchNode(doc(p('prepended'), p()));
+        expect(get$Cursor(view.state.selection)?.pos).toBe(
+            view.state.doc.nodeSize - 3, // the cursor should not move
+        );
+    });
+
+    it('should prepend markup to not empty document', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('content')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.prepend('prepended');
+        expect(view.state.doc).toMatchNode(doc(p('prepended'), p('content')));
+        // the cursor should not move
+        expect(get$Cursor(view.state.selection)?.pos).toBe(3 + 'prepended'.length);
+    });
+
+    it('should replace markup', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('content')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.replace('replaced');
+        expect(view.state.doc).toMatchNode(doc(p('replaced')));
+    });
+
+    it('should move cursor to start of document', () => {
+        const document = doc(p('paragraph content'));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 7),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.moveCursor('start');
+        expect(get$Cursor(view.state.selection)?.pos).toBe(1);
+    });
+
+    it('should move cursor to end of document', () => {
+        const document = doc(p('paragraph content'));
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: document,
+                selection: TextSelection.create(document, 7),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        contentHandler.moveCursor('end');
+        expect(get$Cursor(view.state.selection)?.pos).toBe(document.nodeSize - 3);
+    });
+
+    it('should throw an error when calling moveCursor with an unknown position', () => {
+        const view = new EditorView(null, {
+            state: EditorState.create({
+                doc: doc(p('content')),
+            }),
+        });
+        const contentHandler = new WysiwygContentHandler(view, fakeParser);
+        const fn = jest.fn(() => {
+            contentHandler.moveCursor('test' as 'start');
+        });
+        expect(fn).toThrow();
+    });
+});

--- a/src/core/ContentHandler.ts
+++ b/src/core/ContentHandler.ts
@@ -34,7 +34,20 @@ export class WysiwygContentHandler implements ContentHandler {
     }
 
     append(markup: MarkupString): void {
-        this.#view.dispatch(this.appendContentTr(this.#view.state.tr, markup));
+        let tr = this.#view.state.tr;
+
+        if (tr.doc.lastChild?.type.name === 'paragraph' && tr.doc.lastChild.childCount === 0) {
+            const pos = tr.doc.nodeSize - 3;
+            tr = tr.replaceWith(pos - 1, pos + 1, this.#parser.parse(markup));
+        } else {
+            tr = this.appendContentTr(tr, markup);
+        }
+
+        if (tr.doc.lastChild?.type.name !== 'paragraph' || tr.doc.lastChild.childCount !== 0) {
+            tr = this.appendContentTr(tr, '');
+        }
+
+        this.#view.dispatch(tr);
     }
 
     moveCursor(position: 'start' | 'end'): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export {markInputRule, nodeInputRule, inlineNodeInputRule} from './utils/inputru
 export {findMark, isMarkActive} from './utils/marks';
 export {findFirstTextblockChild, isNodeEmpty, isCodeBlock, isSelectableNode} from './utils/nodes';
 export {nodeTypeFactory, markTypeFactory, isSameNodeType} from './utils/schema';
-export {isTextSelection, isNodeSelection, isWholeSelection} from './utils/selection';
+export {isTextSelection, isNodeSelection, isWholeSelection, get$Cursor} from './utils/selection';
 export * from './table-utils';


### PR DESCRIPTION
1. Сontrols have been added to the Playground that allow you to perform methods of modifying the current content (append, prepend, replace, clear, etc.)
2. Added tests for content handler
3. Fixed `.append()` method: now it replaces last empty paragraph with the passed markup and, if necessary, adds an empty paragraph after