### PR TITLE
feat(Link): when pasting, create a link with the pasted URL and selected text

### DIFF
--- a/src/core/ContentHandler.test.ts
+++ b/src/core/ContentHandler.test.ts
@@ -23,6 +23,9 @@ const fakeParser: Parser = {
     parse(markup) {
         return doc(p(markup));
     },
+    matchLinks(_text: string) {
+        throw new Error('Function not implemented.');
+    },
     validateLink(_url: string): boolean {
         throw new Error('Function not implemented.');
     },

--- a/src/core/markdown/MarkdownParser.ts
+++ b/src/core/markdown/MarkdownParser.ts
@@ -1,3 +1,4 @@
+import type {Match} from 'linkify-it';
 import type MarkdownIt from 'markdown-it';
 import type Token from 'markdown-it/lib/token';
 import {Mark, MarkType, Node, NodeType, Schema} from 'prosemirror-model';
@@ -38,6 +39,10 @@ export class MarkdownParser implements Parser {
 
     normalizeLinkText(url: string): string {
         return this.tokenizer.normalizeLinkText(url);
+    }
+
+    matchLinks(text: string): Readonly<Match>[] | null {
+        return this.tokenizer.linkify.match(text);
     }
 
     parse(text: string) {

--- a/src/core/types/parser.ts
+++ b/src/core/types/parser.ts
@@ -1,3 +1,4 @@
+import type {Match} from 'linkify-it';
 import type Token from 'markdown-it/lib/token';
 import type {Node} from 'prosemirror-model';
 
@@ -7,6 +8,7 @@ export interface Parser {
     validateLink(url: string): boolean;
     normalizeLink(url: string): string;
     normalizeLinkText(url: string): string;
+    matchLinks(text: string): Readonly<Match>[] | null;
 }
 
 export interface ParserToken {

--- a/src/extensions/markdown/Link/index.ts
+++ b/src/extensions/markdown/Link/index.ts
@@ -4,6 +4,7 @@ import type {Fragment, Mark, MarkType} from 'prosemirror-model';
 import type {Action, ExtensionAuto} from '../../../core';
 import {markTypeFactory} from '../../../utils/schema';
 import {LinkActionMeta, LinkActionParams, linkCommand} from './actions';
+import {linkPasteEnhance} from './paste-plugin';
 
 export type {LinkActionParams} from './actions';
 export {normalizeUrlFactory} from './utils';
@@ -83,6 +84,7 @@ export const Link: ExtensionAuto = (builder) => {
                 },
             },
         }))
+        .addPlugin(linkPasteEnhance, builder.PluginPriority.High)
         .addAction(linkAction, (deps) => linkCommand(linkType(deps.schema), deps))
         .addInputRules(({schema}) => ({rules: [linkInputRule(linkType(schema))]}));
 };

--- a/src/extensions/markdown/Link/paste-plugin.ts
+++ b/src/extensions/markdown/Link/paste-plugin.ts
@@ -1,0 +1,47 @@
+import {Plugin, TextSelection} from 'prosemirror-state';
+import {isTextSelection} from '../../../utils/selection';
+import type {ExtensionDeps, Parser} from '../../../core';
+import {DataTransferType, isIosSafariShare} from '../../behavior/Clipboard/utils';
+import {LinkAttr, linkType} from './index';
+
+export function linkPasteEnhance({parser}: ExtensionDeps) {
+    return new Plugin({
+        props: {
+            // @ts-expect-error handleDOMEvents has broken types
+            handleDOMEvents: {
+                paste(view, e): boolean {
+                    const {state, dispatch} = view;
+                    const sel = state.selection;
+                    if (!isTextSelection(sel)) return false;
+                    const {$from, $to} = sel;
+                    if ($from.pos !== $to.pos && $from.sameParent($to)) {
+                        const url = getUrl(e.clipboardData, parser);
+                        if (url) {
+                            const tr = state.tr.addMark(
+                                $from.pos,
+                                $to.pos,
+                                linkType(state.schema).create({
+                                    [LinkAttr.Href]: url,
+                                }),
+                            );
+                            dispatch(tr.setSelection(TextSelection.create(tr.doc, $to.pos)));
+                            e.preventDefault();
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+            },
+        },
+    });
+}
+
+function getUrl(data: DataTransfer | null, parser: Parser): string | null {
+    if (!data || data.types.includes(DataTransferType.Yfm)) return null;
+    if (isIosSafariShare(data)) return data.getData(DataTransferType.UriList);
+    // TODO: should we process HTML here?
+    const text = data.getData(DataTransferType.Text);
+    const match = parser.matchLinks(text);
+    if (match?.[0]?.raw === text) return match[0].url;
+    return null;
+}


### PR DESCRIPTION
If, when pasting in the editor, the text is selected inside one textblock, and there is a URL in `event.clipboardData`, then create a link with the selected text and the inserted URL