### PR TITLE
fix: correct order for inline code among other mark when serialized to DOM and markup

### DIFF
--- a/src/core/ExtensionBuilder.test.ts
+++ b/src/core/ExtensionBuilder.test.ts
@@ -1,6 +1,6 @@
 import {Plugin} from 'prosemirror-state';
 import {ExtensionBuilder} from './ExtensionBuilder';
-import type {ExtensionDeps} from './types/extension';
+import type {ExtensionDeps, YEMarkSpec} from './types/extension';
 
 describe('ExtensionBuilder', () => {
     it('should build empty extension', () => {
@@ -62,6 +62,46 @@ describe('ExtensionBuilder', () => {
         expect(marks.size).toBe(2);
         expect(marks.get('mark1')).toBeTruthy();
         expect(marks.get('mark2')).toBeTruthy();
+    });
+
+    it('should sort marks by priority', () => {
+        const mark0: YEMarkSpec = {
+            spec: {},
+            fromYfm: {tokenSpec: {type: 'mark', name: 'mark0'}},
+            toYfm: {open: '', close: ''},
+        };
+        const mark1: YEMarkSpec = {
+            spec: {},
+            fromYfm: {tokenSpec: {type: 'mark', name: 'mark1'}},
+            toYfm: {open: '', close: ''},
+        };
+        const mark2: YEMarkSpec = {
+            spec: {},
+            fromYfm: {tokenSpec: {type: 'mark', name: 'mark2'}},
+            toYfm: {open: '', close: ''},
+        };
+        const mark3: YEMarkSpec = {
+            spec: {},
+            fromYfm: {tokenSpec: {type: 'mark', name: 'mark3'}},
+            toYfm: {open: '', close: ''},
+        };
+        const marksOrderedMap = new ExtensionBuilder()
+            .addMark('mark3', () => mark3, ExtensionBuilder.Priority.VeryLow)
+            .addMark('mark1', () => mark1)
+            .addMark('mark0', () => mark0, ExtensionBuilder.Priority.VeryHigh)
+            .addMark('mark2', () => mark2)
+            .build()
+            .marks();
+        const marksList: {name: string; spec: YEMarkSpec}[] = [];
+        marksOrderedMap.forEach((name, spec) => marksList.push({name, spec}));
+        expect(marksList[0].name).toBe('mark0');
+        expect(marksList[0].spec === mark0).toBe(true);
+        expect(marksList[1].name).toBe('mark1');
+        expect(marksList[1].spec === mark1).toBe(true);
+        expect(marksList[2].name).toBe('mark2');
+        expect(marksList[2].spec === mark2).toBe(true);
+        expect(marksList[3].name).toBe('mark3');
+        expect(marksList[3].spec === mark3).toBe(true);
     });
 
     it('should add plugins', () => {

--- a/src/extensions/markdown/Code/Code.test.ts
+++ b/src/extensions/markdown/Code/Code.test.ts
@@ -2,17 +2,22 @@ import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
+import {bold, Bold} from '../Bold';
+import {italic, Italic} from '../Italic';
 import {code, Code} from './index';
 
 const {schema, parser, serializer} = new ExtensionsManager({
-    extensions: (builder) => builder.use(BaseSchema, {}).use(Code, {}),
+    extensions: (builder) =>
+        builder.use(BaseSchema, {}).use(Bold, {}).use(Code, {}).use(Italic, {}),
 }).buildDeps();
 
-const {doc, p, c} = builders(schema, {
+const {doc, p, b, i, c} = builders(schema, {
     doc: {nodeType: BaseNode.Doc},
     p: {nodeType: BaseNode.Paragraph},
+    b: {nodeType: bold},
+    i: {nodeType: italic},
     c: {nodeType: code},
-}) as PMTestBuilderResult<'doc' | 'p', 'c'>;
+}) as PMTestBuilderResult<'doc' | 'p', 'b' | 'i' | 'c'>;
 
 const {same} = createMarkupChecker({parser, serializer});
 
@@ -21,4 +26,10 @@ describe('Code extension', () => {
 
     it('should parse code inside text', () =>
         same('he`llo wor`ld!', doc(p('he', c('llo wor'), 'ld!'))));
+
+    it('should parse and serialize overlapping inline marks', () =>
+        same(
+            'This is **strong *emphasized text with `code` in* it**',
+            doc(p('This is ', b('strong ', i('emphasized text with ', c('code'), ' in'), ' it'))),
+        ));
 });

--- a/src/extensions/markdown/Code/index.ts
+++ b/src/extensions/markdown/Code/index.ts
@@ -17,28 +17,32 @@ export type CodeOptions = {
 
 export const Code: ExtensionAuto<CodeOptions> = (builder, opts) => {
     builder
-        .addMark(code, () => ({
-            spec: {
-                code: true,
-                parseDOM: [{tag: 'code'}],
-                toDOM() {
-                    return ['code'];
+        .addMark(
+            code,
+            () => ({
+                spec: {
+                    code: true,
+                    parseDOM: [{tag: 'code'}],
+                    toDOM() {
+                        return ['code'];
+                    },
                 },
-            },
-            toYfm: {
-                open(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index), -1);
+                toYfm: {
+                    open(_state, _mark, parent, index) {
+                        return backticksFor(parent.child(index), -1);
+                    },
+                    close(_state, _mark, parent, index) {
+                        return backticksFor(parent.child(index - 1), 1);
+                    },
+                    escape: false,
                 },
-                close(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index - 1), 1);
+                fromYfm: {
+                    tokenSpec: {name: code, type: 'mark', noCloseToken: true},
+                    tokenName: 'code_inline',
                 },
-                escape: false,
-            },
-            fromYfm: {
-                tokenSpec: {name: code, type: 'mark', noCloseToken: true},
-                tokenName: 'code_inline',
-            },
-        }))
+            }),
+            builder.Priority.Lowest,
+        )
         .addAction(codeAction, ({schema}) => createToggleMarkAction(codeType(schema)));
 
     if (opts?.codeKey) {


### PR DESCRIPTION
Order of marks in schema is important for prosemirror and it affects the serialization of the prosemirror-document in DOM or markdown markup. The problem occurred when `code_inline` overlapped with other marks that were in the schema after it. I added marks priority support to `ExtensionBuilder`, and set lowest priority for `code_inline`.