### PR TITLE
fix: re-export MathNode classes

### DIFF
--- a/src/extensions/yfm/Math/index.ts
+++ b/src/extensions/yfm/Math/index.ts
@@ -10,6 +10,9 @@ import {inlineNodeInputRule} from '../../../utils/inputrules';
 import {mathViewAndEditPlugin} from './view-and-edit';
 import {MathNode} from './const';
 
+export {MathNode} from './const';
+export {MathBlockNodeView, MathInlineNodeView} from './view-and-edit';
+
 const mathIType = nodeTypeFactory(MathNode.Inline);
 const mathBType = nodeTypeFactory(MathNode.Block);
 


### PR DESCRIPTION
I would like to extend the behaviour of the Math plugin in my project, so I have to import MathNode, MathBlockNodeView and MathInlineNodeView. But instead of

```typescript
import { MathNode, MathBlockNodeView, MathInlineNodeView } from '@doc-tools/yfm-editor';
```

I have to write something like this:

```typescript
import { MathBlockNodeView, MathInlineNodeView } from '@doc-tools/yfm-editor/build/esm/extensions/yfm/Math/view-and-edit';
import { MathNode } from '@doc-tools/yfm-editor/build/esm/extensions/yfm/Math/const';
```

So I added export of these items.

I am not sure it is needed publish a minor update, so I named the commit like "fix" to up the patch version.