### PR TITLE
feat: parse html from the clipboard when pasting

### DIFF
--- a/src/extensions/base/BaseSchema/index.ts
+++ b/src/extensions/base/BaseSchema/index.ts
@@ -47,7 +47,7 @@ export const BaseSchema: ExtensionAuto<BaseSchemaOptions> = (builder, opts) => {
         }))
         .addNode(BaseNode.Paragraph, () => ({
             spec: {
-                content: '(text | inline)*',
+                content: 'inline*',
                 group: 'block',
                 parseDOM: [{tag: 'p'}],
                 toDOM() {

--- a/src/extensions/behavior/Clipboard/clipboard.ts
+++ b/src/extensions/behavior/Clipboard/clipboard.ts
@@ -96,6 +96,13 @@ export const clipboard = ({
                     }
 
                     if (
+                        !e.clipboardData.types.includes(DataTransferType.Yfm) &&
+                        (data = e.clipboardData.getData(DataTransferType.Html))
+                    ) {
+                        return false; // default html pasting
+                    }
+
+                    if (
                         (data = e.clipboardData.getData(DataTransferType.Yfm)) ||
                         (data = e.clipboardData.getData(DataTransferType.Text))
                     ) {

--- a/src/extensions/behavior/Clipboard/utils.ts
+++ b/src/extensions/behavior/Clipboard/utils.ts
@@ -4,6 +4,7 @@ export enum DataTransferType {
     Html = 'text/html',
     Yfm = 'text/yfm', // self
     UriList = 'text/uri-list',
+    VSCodeData = 'vscode-editor-data',
     Files = 'Files',
 }
 

--- a/src/extensions/markdown/Blockquote/Blockquote.test.ts
+++ b/src/extensions/markdown/Blockquote/Blockquote.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {blockquote, Blockquote} from './index';
@@ -23,5 +24,13 @@ describe('Blockquote extension', () => {
 
     it('should parse a blockquote with few paragraphs', () => {
         same(['> hello', '>', '> world!'].join('\n'), doc(q(p('hello'), p('world!'))));
+    });
+
+    it('should parse html - blockquote tag', () => {
+        parseDOM(
+            schema,
+            '<div><blockquote>text in blockquote</blockquote></div>',
+            doc(q(p('text in blockquote'))),
+        );
     });
 });

--- a/src/extensions/markdown/Bold/Bold.test.ts
+++ b/src/extensions/markdown/Bold/Bold.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {bold, Bold} from './index';
@@ -23,4 +24,32 @@ describe('Bold extension', () => {
 
     it('should parse bold inside text', () =>
         same('he**llo wor**ld!', doc(p('he', b('llo wor'), 'ld!'))));
+
+    it('should parse html - em tag', () => {
+        parseDOM(schema, '<p><b>text in b tag</b></p>', doc(p(b('text in b tag'))));
+    });
+
+    it('should parse html - strong tag', () => {
+        parseDOM(
+            schema,
+            '<div><strong>text in strong tag</strong></div>',
+            doc(p(b('text in strong tag'))),
+        );
+    });
+
+    it('should parse html - font-weight:bold', () => {
+        parseDOM(schema, '<div style="font-weight:bold">bold text</div>', doc(p(b('bold text'))));
+    });
+
+    it('should parse html - font-weight:bolder', () => {
+        parseDOM(
+            schema,
+            '<div style="font-weight:bolder">bolder text</div>',
+            doc(p(b('bolder text'))),
+        );
+    });
+
+    it('should parse html - font-weight:700', () => {
+        parseDOM(schema, '<div style="font-weight:700">700</div>', doc(p(b('700'))));
+    });
 });

--- a/src/extensions/markdown/Bold/index.ts
+++ b/src/extensions/markdown/Bold/index.ts
@@ -16,7 +16,15 @@ export const Bold: ExtensionAuto<BoldOptions> = (builder, opts) => {
     builder
         .addMark(bold, () => ({
             spec: {
-                parseDOM: [{tag: 'strong'}],
+                parseDOM: [
+                    {tag: 'b'},
+                    {tag: 'strong'},
+                    {
+                        style: 'font-weight',
+                        getAttrs: (value) =>
+                            /^(bold(er)?|[5-9]\d{2,})$/.test(value as string) && null,
+                    },
+                ],
                 toDOM() {
                     return ['strong'];
                 },

--- a/src/extensions/markdown/Breaks/Breaks.test.ts
+++ b/src/extensions/markdown/Breaks/Breaks.test.ts
@@ -1,0 +1,21 @@
+import {builders} from 'prosemirror-test-builder';
+import {parseDOM} from '../../../../tests/parse-dom';
+import {ExtensionsManager} from '../../../core';
+import {BaseNode, BaseSchema} from '../../base/BaseSchema';
+import {Breaks, hbType} from './index';
+
+const {schema} = new ExtensionsManager({
+    extensions: (builder) => builder.use(BaseSchema, {}).use(Breaks, {}),
+}).buildDeps();
+
+const {doc, p, hb} = builders(schema, {
+    doc: {nodeType: BaseNode.Doc},
+    p: {nodeType: BaseNode.Paragraph},
+    hb: {nodeType: hbType(schema).name},
+}) as PMTestBuilderResult<'doc' | 'p' | 'hb'>;
+
+describe('Breaks extension', () => {
+    it('should parse html - br tag', () => {
+        parseDOM(schema, '<div>hello<br>world!</div>', doc(p('hello', hb(), 'world!')));
+    });
+});

--- a/src/extensions/markdown/Code/Code.test.ts
+++ b/src/extensions/markdown/Code/Code.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {bold, Bold} from '../Bold';
@@ -32,4 +33,8 @@ describe('Code extension', () => {
             'This is **strong *emphasized text with `code` in* it**',
             doc(p('This is ', b('strong ', i('emphasized text with ', c('code'), ' in'), ' it'))),
         ));
+
+    it('should parse html - code tag', () => {
+        parseDOM(schema, '<code>code inline</code>', doc(p(c('code inline'))));
+    });
 });

--- a/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
@@ -4,6 +4,7 @@
 
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {CodeBlock} from './index';
@@ -39,4 +40,9 @@ describe('CodeBlock extension', () => {
             'foo\n\n```javascript\n1\n```',
             doc(p('foo'), schema.node(codeBlock, {[langAttr]: 'javascript'}, [schema.text('1\n')])),
         ));
+
+    // TODO: parsed: doc(paragraph("code\nblock"))
+    it.skip('should parse html - pre tag', () => {
+        parseDOM(schema, '<pre><code>code\nblock</code></pre>', doc(cb('code\nblock')));
+    });
 });

--- a/src/extensions/markdown/CodeBlock/handle-paste.ts
+++ b/src/extensions/markdown/CodeBlock/handle-paste.ts
@@ -1,0 +1,53 @@
+import type {EditorProps} from 'prosemirror-view';
+import {DataTransferType} from '../../behavior/Clipboard/utils';
+import {cbType, langAttr} from './const';
+
+export const handlePaste: NonNullable<EditorProps['handlePaste']> = (view, e) => {
+    if (!e.clipboardData || view.state.selection.$from.parent.type.spec.code) return false;
+    const code = getCodeData(e.clipboardData);
+    if (!code) return false;
+    let tr = view.state.tr;
+    const {schema} = tr.doc.type;
+    const codeBlockNode = cbType(schema).create({[langAttr]: code.mode}, schema.text(code.value));
+    tr = tr.replaceSelectionWith(codeBlockNode);
+    view.dispatch(tr.scrollIntoView());
+    return true;
+};
+
+function getCodeData(data: DataTransfer): null | {editor: string; mode?: string; value: string} {
+    if (data.getData(DataTransferType.Text)) {
+        let editor = 'unknown';
+        let mode: string | undefined;
+
+        if (isVSCode(data)) {
+            editor = 'vscode';
+            mode = tryCatch<VSCodeData>(() =>
+                JSON.parse(data.getData(DataTransferType.VSCodeData)),
+            )?.mode;
+        } else return null;
+
+        return {editor, mode, value: data.getData(DataTransferType.Text)};
+    }
+    return null;
+}
+
+type VSCodeData = {
+    version: number;
+    isFromEmptySelection: boolean;
+    multicursorText: null | string;
+    mode: string;
+    [key: string]: unknown;
+};
+
+function isVSCode(data: DataTransfer): boolean {
+    return data.types.includes(DataTransferType.VSCodeData);
+}
+
+function tryCatch<R>(fn: () => R): R | undefined {
+    try {
+        return fn();
+    } catch (e) {
+        console.error(e);
+    }
+    return undefined;
+}

--- a/src/extensions/markdown/CodeBlock/index.ts
+++ b/src/extensions/markdown/CodeBlock/index.ts
@@ -1,10 +1,12 @@
 import {setBlockType} from 'prosemirror-commands';
 import {textblockTypeInputRule} from 'prosemirror-inputrules';
-import {NodeType} from 'prosemirror-model';
+import {NodeType, Slice} from 'prosemirror-model';
+import {Plugin} from 'prosemirror-state';
 import {hasParentNodeOfType} from 'prosemirror-utils';
 import type {Action, ExtensionAuto, Keymap} from '../../../core';
 import {resetCodeblock} from './commands';
 import {cbAction, cbType, codeBlock, langAttr} from './const';
+import {handlePaste} from './handle-paste';
 
 export type CodeBlockOptions = {
     codeBlockKey?: string | null;
@@ -83,6 +85,24 @@ export const CodeBlock: ExtensionAuto<CodeBlockOptions> = (builder, opts) => {
             run: cmd,
         };
     });
+
+    builder.addPlugin(
+        () =>
+            new Plugin({
+                props: {
+                    handleDOMEvents: {
+                        paste(view, e: Event) {
+                            if (handlePaste(view, e as ClipboardEvent, Slice.empty)) {
+                                e.preventDefault();
+                                return true;
+                            }
+                            return false;
+                        },
+                    },
+                },
+            }),
+        builder.Priority.High,
+    );
 };
 
 declare global {

--- a/src/extensions/markdown/Deflist/Deflist.test.ts
+++ b/src/extensions/markdown/Deflist/Deflist.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {Deflist} from './index';
@@ -61,6 +62,15 @@ Term 2
                     dd(p('Description 2')),
                 ),
             ),
+        );
+    });
+
+    // TODO: pasrsed to: doc(dt("Term"), dd(paragraph("Description")))
+    it.skip('should parse html', () => {
+        parseDOM(
+            schema,
+            '<div><dl><dt>Term</dt><dd>Description</dd></dl></div>',
+            doc(dl(dt('Term'), dd(p('Description')))),
         );
     });
 });

--- a/src/extensions/markdown/Heading/Heading.test.ts
+++ b/src/extensions/markdown/Heading/Heading.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {bold, Bold} from '../Bold';
@@ -10,17 +11,18 @@ const {schema, parser, serializer} = new ExtensionsManager({
     extensions: (builder) => builder.use(BaseSchema, {}).use(Heading, {}).use(Bold, {}),
 }).buildDeps();
 
-const {doc, b, p, h1, h2, h3, h4, h5, h6} = builders(schema, {
+const {doc, b, p, h, h1, h2, h3, h4, h5, h6} = builders(schema, {
     doc: {nodeType: BaseNode.Doc},
     b: {nodeType: bold},
     p: {nodeType: BaseNode.Paragraph},
+    h: {nodeType: heading},
     h1: {nodeType: heading, [lvlAttr]: 1},
     h2: {nodeType: heading, [lvlAttr]: 2},
     h3: {nodeType: heading, [lvlAttr]: 3},
     h4: {nodeType: heading, [lvlAttr]: 4},
     h5: {nodeType: heading, [lvlAttr]: 5},
     h6: {nodeType: heading, [lvlAttr]: 6},
-}) as PMTestBuilderResult<'doc' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', 'b'>;
+}) as PMTestBuilderResult<'doc' | 'p' | 'h' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', 'b'>;
 
 const {same} = createMarkupChecker({parser, serializer});
 
@@ -49,7 +51,7 @@ describe('Heading extension', () => {
         same('###### six', doc(h6('six')));
     });
 
-    it('should parse haeding wiht marks', () => {
+    it('should parse heading with marks', () => {
         same('## heading with **bold**', doc(h2('heading with ', b('bold'))));
     });
 
@@ -71,5 +73,13 @@ describe('Heading extension', () => {
         ].join('\n');
 
         same(markup, doc(h1('h1'), h2('h2'), h3('h3'), h4('h4'), h5('h5'), h6('h6'), p('para')));
+    });
+
+    it.each([1, 2, 3, 4, 5, 6])('should parse html - h%s tag', (lvl) => {
+        parseDOM(
+            schema,
+            `<h${lvl}>Heading ${lvl}</h${lvl}>`,
+            doc(h({[lvlAttr]: lvl}, `Heading ${lvl}`)),
+        );
     });
 });

--- a/src/extensions/markdown/HorizontalRule/HorizontalRule.test.ts
+++ b/src/extensions/markdown/HorizontalRule/HorizontalRule.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {horizontalRule, HorizontalRule, markupAttr} from './index';
@@ -35,5 +36,9 @@ world!
         `.trim();
 
         same(markup, doc(p('hello'), hr(), p('world!')));
+    });
+
+    it('should parse html - hr tag', () => {
+        parseDOM(schema, 'hello<hr>world!', doc(p('hello'), hr(), p('world!')));
     });
 });

--- a/src/extensions/markdown/Italic/Italic.test.ts
+++ b/src/extensions/markdown/Italic/Italic.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {italic, Italic} from './index';
@@ -23,4 +24,20 @@ describe('Italic extension', () => {
 
     it('should parse italic inside text', () =>
         same('he*llo wor*ld!', doc(p('he', i('llo wor'), 'ld!'))));
+
+    it('should parse html - em tag', () => {
+        parseDOM(schema, '<p><em>text in em</em></p>', doc(p(i('text in em'))));
+    });
+
+    it('should parse html - i tag', () => {
+        parseDOM(schema, '<div><i>text in i</i></div>', doc(p(i('text in i'))));
+    });
+
+    it('should parse html - font-style:italic', () => {
+        parseDOM(
+            schema,
+            '<div style="font-style:italic">text with styles</div>',
+            doc(p(i('text with styles'))),
+        );
+    });
 });

--- a/src/extensions/markdown/Italic/index.ts
+++ b/src/extensions/markdown/Italic/index.ts
@@ -16,7 +16,11 @@ export const Italic: ExtensionAuto<ItalicOptions> = (builder, opts) => {
     builder
         .addMark(italic, () => ({
             spec: {
-                parseDOM: [{tag: 'em'}],
+                parseDOM: [
+                    {tag: 'i'},
+                    {tag: 'em'},
+                    {style: 'font-style', getAttrs: (value) => value === 'italic' && null},
+                ],
                 toDOM() {
                     return ['em'];
                 },

--- a/src/extensions/markdown/Lists/Lists.test.ts
+++ b/src/extensions/markdown/Lists/Lists.test.ts
@@ -45,7 +45,10 @@ describe('Lists extension', () => {
             markup,
             doc(
                 ul(
-                    li(p('one'), ol(li(p('two'), ul(li(p('three')))), li(p('four')))),
+                    li(
+                        p('one'),
+                        ol(li(p('two'), ul({tight: true}, li(p('three')))), li(p('four'))),
+                    ),
                     li(p('five')),
                 ),
             ),

--- a/src/extensions/markdown/Lists/spec.ts
+++ b/src/extensions/markdown/Lists/spec.ts
@@ -19,9 +19,15 @@ export const spec: Record<ListNode, NodeSpec> = {
     [ListNode.BulletList]: {
         content: `${ListNode.ListItem}+`,
         group: 'block',
-        parseDOM: [{tag: 'ul'}],
-        toDOM() {
-            return ['ul', 0];
+        attrs: {tight: {default: false}},
+        parseDOM: [
+            {
+                tag: 'ul',
+                getAttrs: (dom) => ({tight: (dom as HTMLElement).hasAttribute('data-tight')}),
+            },
+        ],
+        toDOM(node) {
+            return ['ul', {'data-tight': node.attrs.tight ? 'true' : null}, 0];
         },
         selectable: false,
         allowSelection: false,
@@ -37,15 +43,23 @@ export const spec: Record<ListNode, NodeSpec> = {
                 tag: 'ol',
                 getAttrs(dom) {
                     return {
-                        order: (dom as Element).hasAttribute('start')
-                            ? Number((dom as Element).getAttribute('start'))
+                        order: (dom as HTMLElement).hasAttribute('start')
+                            ? Number((dom as HTMLElement).getAttribute('start')!)
                             : 1,
+                        tight: (dom as HTMLElement).hasAttribute('data-tight'),
                     };
                 },
             },
         ],
         toDOM(node) {
-            return node.attrs.order === 1 ? ['ol', 0] : ['ol', {start: node.attrs.order}, 0];
+            return [
+                'ol',
+                {
+                    start: node.attrs.order === 1 ? null : node.attrs.order,
+                    'data-tight': node.attrs.tight ? 'true' : null,
+                },
+                0,
+            ];
         },
         selectable: false,
         allowSelection: false,

--- a/src/extensions/markdown/Strike/Strike.test.ts
+++ b/src/extensions/markdown/Strike/Strike.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {strike, Strike} from './index';
@@ -21,4 +22,12 @@ describe('Strike extension', () => {
 
     it('should parse strike inside text', () =>
         same('he~~llo wor~~ld!', doc(p('he', s('llo wor'), 'ld!'))));
+
+    it('should parse html - strike tag', () => {
+        parseDOM(schema, '<p><strike>strikethrough</strike></p>', doc(p(s('strikethrough'))));
+    });
+
+    it('should parse html - s tag', () => {
+        parseDOM(schema, '<div><s>strikethrough</s></div>', doc(p(s('strikethrough'))));
+    });
 });

--- a/src/extensions/markdown/Strike/index.ts
+++ b/src/extensions/markdown/Strike/index.ts
@@ -16,7 +16,7 @@ export const Strike: ExtensionAuto<StrikeOptions> = (builder, opts) => {
     builder
         .addMark(strike, () => ({
             spec: {
-                parseDOM: [{tag: 'strike'}],
+                parseDOM: [{tag: 'strike'}, {tag: 's'}],
                 toDOM() {
                     return ['strike'];
                 },

--- a/src/extensions/markdown/Subscript/Subscript.test.ts
+++ b/src/extensions/markdown/Subscript/Subscript.test.ts
@@ -3,27 +3,27 @@ import {createMarkupChecker} from '../../../../tests/sameMarkup';
 import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
-import {mark, Mark} from './index';
+import {subscript, Subscript} from './index';
 
 const {schema, parser, serializer} = new ExtensionsManager({
-    extensions: (builder) => builder.use(BaseSchema, {}).use(Mark),
+    extensions: (builder) => builder.use(BaseSchema, {}).use(Subscript, {}),
 }).buildDeps();
 
-const {doc, p, m} = builders(schema, {
+const {doc, p, s} = builders(schema, {
     doc: {nodeType: BaseNode.Doc},
     p: {nodeType: BaseNode.Paragraph},
-    m: {markType: mark},
-}) as PMTestBuilderResult<'doc' | 'p', 'm'>;
+    s: {markType: subscript},
+}) as PMTestBuilderResult<'doc' | 'p', 's'>;
 
 const {same} = createMarkupChecker({parser, serializer});
 
-describe('Mark extension', () => {
-    it('should parse mark', () => same('==hello!==', doc(p(m('hello!')))));
+describe('Subscript extension', () => {
+    it('should parse subscript', () => same('~hello~', doc(p(s('hello')))));
 
-    it('should parse mark inside text', () =>
-        same('he==llo wor==ld!', doc(p('he', m('llo wor'), 'ld!'))));
+    it('should parse subscript inside text', () =>
+        same('hello~world~!', doc(p('hello', s('world'), '!'))));
 
     it('should parse html - sub tag', () => {
-        parseDOM(schema, '<p><mark>marked text</mark></p>', doc(p(m('marked text'))));
+        parseDOM(schema, '<p><sub>subscript</sub></p>', doc(p(s('subscript'))));
     });
 });

--- a/src/extensions/markdown/Subscript/index.ts
+++ b/src/extensions/markdown/Subscript/index.ts
@@ -4,7 +4,7 @@ import {markTypeFactory} from '../../../utils/schema';
 import {markInputRule} from '../../../utils/inputrules';
 const sub = require('markdown-it-sub');
 
-const subscript = 'sub';
+export const subscript = 'sub';
 const subAction = 'subscript';
 const subType = markTypeFactory(subscript);
 

--- a/src/extensions/markdown/Superscript/Superscript.test.ts
+++ b/src/extensions/markdown/Superscript/Superscript.test.ts
@@ -1,0 +1,29 @@
+import {builders} from 'prosemirror-test-builder';
+import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
+import {ExtensionsManager} from '../../../core';
+import {BaseNode, BaseSchema} from '../../base/BaseSchema';
+import {superscript, Superscript} from './index';
+
+const {schema, parser, serializer} = new ExtensionsManager({
+    extensions: (builder) => builder.use(BaseSchema, {}).use(Superscript, {}),
+}).buildDeps();
+
+const {doc, p, s} = builders(schema, {
+    doc: {nodeType: BaseNode.Doc},
+    p: {nodeType: BaseNode.Paragraph},
+    s: {markType: superscript},
+}) as PMTestBuilderResult<'doc' | 'p', 's'>;
+
+const {same} = createMarkupChecker({parser, serializer});
+
+describe('Superscript extension', () => {
+    it('should parse superscript', () => same('^hello^', doc(p(s('hello')))));
+
+    it('should parse superscript inside text', () =>
+        same('hello^world^!', doc(p('hello', s('world'), '!'))));
+
+    it('should parse html - sup tag', () => {
+        parseDOM(schema, '<p><sup>superscript</sup></p>', doc(p(s('superscript'))));
+    });
+});

--- a/src/extensions/markdown/Superscript/index.ts
+++ b/src/extensions/markdown/Superscript/index.ts
@@ -5,7 +5,7 @@ import {markInputRule} from '../../../utils/inputrules';
 import log from '@doc-tools/transform/lib/log';
 const sup = require('@doc-tools/transform/lib/plugins/sup');
 
-const superscript = 'sup';
+export const superscript = 'sup';
 const supAction = 'supscript';
 const supType = markTypeFactory(superscript);
 

--- a/src/extensions/markdown/Table/Table.test.ts
+++ b/src/extensions/markdown/Table/Table.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {blockquote, Blockquote} from '../Blockquote';
@@ -87,6 +88,27 @@ describe('Table extension', () => {
                             tr(tdL('Text 4'), tdC('Text 5'), tdR('Text 6')),
                         ),
                     ),
+                ),
+            ),
+        );
+    });
+
+    it('should parse html', () => {
+        parseDOM(
+            schema,
+            '<table>' +
+                '<thead>' +
+                '<tr><th>1</th><th>2</th></tr>' +
+                '</thead>' +
+                '<tbody>' +
+                '<tr><td>3</td><td>4</td></tr>' +
+                '<tr><td>5</td><td>6</td></tr>' +
+                '</tbody>' +
+                '</tbody>',
+            doc(
+                table(
+                    thead(tr(thL('1'), thL('2'))),
+                    tbody(tr(tdL('3'), tdL('4')), tr(tdL('5'), tdL('6'))),
                 ),
             ),
         );

--- a/src/extensions/markdown/Table/spec.ts
+++ b/src/extensions/markdown/Table/spec.ts
@@ -76,6 +76,7 @@ function cellTemplate(tag: 'th' | 'td'): NodeSpec {
             {
                 tag,
                 getAttrs(dom) {
+                    if (!(dom as Element).hasAttribute(TableAttrs.CellAlign)) return null;
                     return {
                         [TableAttrs.CellAlign]: (dom as Element).getAttribute(TableAttrs.CellAlign),
                     };

--- a/src/extensions/markdown/Underline/Underline.test.ts
+++ b/src/extensions/markdown/Underline/Underline.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {underline, Underline} from './index';
@@ -21,4 +22,12 @@ describe('Underline extension', () => {
 
     it('should parse underline inside text', () =>
         same('he++llo wor++ld!', doc(p('he', u('llo wor'), 'ld!'))));
+
+    it('should parse html - ins tag', () => {
+        parseDOM(schema, '<p><ins>underline</ins></p>', doc(p(u('underline'))));
+    });
+
+    it('should parse html - u tag', () => {
+        parseDOM(schema, '<div><u>underline</u></div>', doc(p(u('underline'))));
+    });
 });

--- a/src/extensions/markdown/Underline/index.ts
+++ b/src/extensions/markdown/Underline/index.ts
@@ -18,7 +18,7 @@ export const Underline: ExtensionAuto<UnderlineOptions> = (builder, opts) => {
         .configureMd((md) => md.use(ins))
         .addMark(underline, () => ({
             spec: {
-                parseDOM: [{tag: 'ins'}],
+                parseDOM: [{tag: 'ins'}, {tag: 'u'}],
                 toDOM() {
                     return ['ins'];
                 },

--- a/src/extensions/yfm/Monospace/Monospace.test.ts
+++ b/src/extensions/yfm/Monospace/Monospace.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {monospace, Monospace} from './index';
@@ -21,4 +22,8 @@ describe('Monospace extension', () => {
 
     it('should parse monospace inside text', () =>
         same('he##llo wor##ld!', doc(p('he', m('llo wor'), 'ld!'))));
+
+    it('should parse html - samp tag', () => {
+        parseDOM(schema, '<samp>hello world!</samp>', doc(p(m('hello world!'))));
+    });
 });

--- a/src/extensions/yfm/YfmCut/YfmCut.test.ts
+++ b/src/extensions/yfm/YfmCut/YfmCut.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {blockquote, Blockquote, italic, Italic} from '../../markdown';
@@ -87,5 +88,16 @@ cut content
     `.trim();
 
         same(markup, doc(cut(cutTitle(i('cut italic title')), cutContent(p('cut content')))));
+    });
+
+    it('should parse yfm-note from html', () => {
+        parseDOM(
+            schema,
+            '<div class="yfm-cut">' +
+                '<div class="yfm-cut-title">YfmCut title</div>' +
+                '<div><p>YfmCut content</p></div' +
+                '</div>',
+            doc(cut(cutTitle('YfmCut title'), cutContent(p('YfmCut content')))),
+        );
     });
 });

--- a/src/extensions/yfm/YfmCut/spec.ts
+++ b/src/extensions/yfm/YfmCut/spec.ts
@@ -15,7 +15,7 @@ export const getSpec = (opts?: YfmCutSpecOptions): Record<CutNode, NodeSpec> => 
     [CutNode.Cut]: {
         attrs: {class: {default: 'yfm-cut'}},
         content: `${CutNode.CutTitle} ${CutNode.CutContent}`,
-        group: 'block',
+        group: 'block yfm-cut',
         parseDOM: [{tag: 'div.yfm-cut'}],
         toDOM(node) {
             return ['div', node.attrs, 0];
@@ -30,7 +30,7 @@ export const getSpec = (opts?: YfmCutSpecOptions): Record<CutNode, NodeSpec> => 
     [CutNode.CutTitle]: {
         attrs: {class: {default: 'yfm-cut-title'}},
         content: 'text*',
-        group: 'block',
+        group: 'block yfm-cut',
         parseDOM: [{tag: 'div.yfm-cut-title'}],
         toDOM(node) {
             return ['div', node.attrs, 0];
@@ -47,7 +47,7 @@ export const getSpec = (opts?: YfmCutSpecOptions): Record<CutNode, NodeSpec> => 
     [CutNode.CutContent]: {
         attrs: {class: {default: 'yfm-cut-content'}},
         content: '(block | paragraph)+',
-        group: 'block',
+        group: 'block yfm-cut',
         parseDOM: [{tag: 'div.yfm-cut-content'}],
         toDOM(node) {
             return ['div', node.attrs, 0];

--- a/src/extensions/yfm/YfmFile/YfmFile.test.ts
+++ b/src/extensions/yfm/YfmFile/YfmFile.test.ts
@@ -2,6 +2,7 @@ import {FILE_TOKEN} from '@doc-tools/transform/lib/plugins/file/const';
 import {builders} from 'prosemirror-test-builder';
 
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {YfmFile} from './index';
@@ -67,6 +68,22 @@ describe('YFM File extension', () => {
                         rel: 'help',
                         target: '_top',
                         type: 'text/markdown',
+                    }),
+                ),
+            ),
+        );
+    });
+
+    it('should parse yfm-file from html', () => {
+        parseDOM(
+            schema,
+            '<div>File: <a class="yfm-file" href="path/to/readme" download="readme.md"></a><div>',
+            doc(
+                p(
+                    'File: ',
+                    file({
+                        href: 'path/to/readme',
+                        download: 'readme.md',
                     }),
                 ),
             ),

--- a/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
+++ b/src/extensions/yfm/YfmHeading/YfmHeading.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {bold, Bold} from '../../markdown/Bold';
@@ -11,17 +12,18 @@ const {schema, parser, serializer} = new ExtensionsManager({
     options: {attrsOpts: {allowedAttributes: ['id']}},
 }).buildDeps();
 
-const {doc, b, p, h1, h2, h3, h4, h5, h6} = builders(schema, {
+const {doc, b, p, h, h1, h2, h3, h4, h5, h6} = builders(schema, {
     doc: {nodeType: BaseNode.Doc},
     b: {nodeType: bold},
     p: {nodeType: BaseNode.Paragraph},
+    h: {nodeType: heading},
     h1: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 1},
     h2: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 2},
     h3: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 3},
     h4: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 4},
     h5: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 5},
     h6: {nodeType: heading, [YfmHeadingAttr.Id]: '', [YfmHeadingAttr.Level]: 6},
-}) as PMTestBuilderResult<'doc' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', 'b'>;
+}) as PMTestBuilderResult<'doc' | 'p' | 'h' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6', 'b'>;
 
 const {same} = createMarkupChecker({parser, serializer});
 
@@ -85,6 +87,14 @@ para
                 h6({[YfmHeadingAttr.Id]: 'six'}, 'h6'),
                 p('para'),
             ),
+        );
+    });
+
+    it.each([1, 2, 3, 4, 5, 6])('should parse html - h%s tag', (lvl) => {
+        parseDOM(
+            schema,
+            `<h${lvl}>Heading ${lvl}</h${lvl}>`,
+            doc(h({[YfmHeadingAttr.Level]: lvl}, `Heading ${lvl}`)),
         );
     });
 });

--- a/src/extensions/yfm/YfmNote/YfmNote.test.ts
+++ b/src/extensions/yfm/YfmNote/YfmNote.test.ts
@@ -1,5 +1,6 @@
 import {builders} from 'prosemirror-test-builder';
 import {createMarkupChecker} from '../../../../tests/sameMarkup';
+import {parseDOM} from '../../../../tests/parse-dom';
 import {ExtensionsManager} from '../../../core';
 import {BaseNode, BaseSchema} from '../../base/BaseSchema';
 import {italic, Italic, blockquote, Blockquote} from '../../markdown';
@@ -83,5 +84,17 @@ note content
 
         // eslint-disable-next-line prettier/prettier
         same(markup, doc(note(noteTitle(i('note italic title')), p('note content'))));
+    });
+
+    // TODO: parsed: doc(paragraph("YfmNote title"), paragraph("YfmNote content"))
+    it.skip('should parse yfm-note from html', () => {
+        parseDOM(
+            schema,
+            '<div><div class="yfm-note yfm-accent-info" note-type="info">' +
+                '<p class="yfm-note-title">YfmNote title</p>' +
+                '<p>YfmNote content</p>' +
+                '</div></div>',
+            doc(note(noteTitle('YfmNote title'), p('YfmNote content'))),
+        );
     });
 });

--- a/src/extensions/yfm/YfmNote/spec.ts
+++ b/src/extensions/yfm/YfmNote/spec.ts
@@ -14,13 +14,14 @@ export const getSpec = (opts?: YfmNoteSpecOptions): Record<NoteNode, NodeSpec> =
             [NoteAttrs.Type]: {default: 'info'},
         },
         content: `${NoteNode.NoteTitle} block+`,
-        group: 'block',
+        group: 'block yfm-note',
         parseDOM: [
             {
                 tag: 'div.yfm-note',
+                priority: 100,
                 getAttrs: (node) => ({
                     [NoteAttrs.Class]: (node as Element).getAttribute(NoteAttrs.Class) || '',
-                    [NoteAttrs.Type]: (node as Element).getAttribute(NoteAttrs.Type) || '',
+                    [NoteAttrs.Type]: (node as Element).getAttribute(NoteAttrs.Type) || 'info',
                 }),
             },
         ],
@@ -35,15 +36,15 @@ export const getSpec = (opts?: YfmNoteSpecOptions): Record<NoteNode, NodeSpec> =
 
     [NoteNode.NoteTitle]: {
         content: 'text*',
-        group: 'block',
+        group: 'block yfm-note',
         parseDOM: [
             {
-                tag: 'p[yfm_block="yfm-note-title"]',
+                tag: 'p.yfm-note-title',
                 priority: 100,
             },
         ],
         toDOM() {
-            return ['p', {yfm_block: 'yfm-note-title'}, 0];
+            return ['p', {class: 'yfm-note-title'}, 0];
         },
         selectable: false,
         allowSelection: false,

--- a/src/extensions/yfm/YfmTable/index.ts
+++ b/src/extensions/yfm/YfmTable/index.ts
@@ -1,3 +1,4 @@
+import {Plugin} from 'prosemirror-state';
 import log from '@doc-tools/transform/lib/log';
 import yfmTable from '@doc-tools/transform/lib/plugins/table';
 import {goToNextCell} from '../../../table-utils';
@@ -9,6 +10,7 @@ import {fromYfm} from './fromYfm';
 import {toYfm} from './toYfm';
 import {goToNextRow} from './commands/goToNextRow';
 import {backspaceCommand} from './commands/backspace';
+import {fixPastedTableBodies} from './paste';
 
 const action = 'createYfmTable';
 
@@ -51,6 +53,17 @@ export const YfmTable: ExtensionWithOptions<YfmTableOptions> = (builder, options
         }))
 
         .addAction(action, () => createYfmTable);
+
+    builder.addPlugin(
+        ({schema}) =>
+            new Plugin({
+                props: {
+                    transformPasted(slice) {
+                        return fixPastedTableBodies(slice, schema);
+                    },
+                },
+            }),
+    );
 };
 
 declare global {

--- a/src/extensions/yfm/YfmTable/paste.ts
+++ b/src/extensions/yfm/YfmTable/paste.ts
@@ -1,0 +1,20 @@
+import {Fragment, Node, Schema, Slice} from 'prosemirror-model';
+import {getContentAsArray, yfmTableBodyType, yfmTableType} from './utils';
+
+export function fixPastedTableBodies(slice: Slice, schema: Schema): Slice {
+    if (slice.content.firstChild?.type === yfmTableBodyType(schema)) {
+        const tRows: Node[] = [];
+        let bodiesSize = 0;
+        for (const {node, offset} of getContentAsArray(slice.content)) {
+            if (node.type !== yfmTableBodyType(schema)) break;
+            tRows.push(...getContentAsArray(node).map((item) => item.node));
+            bodiesSize = offset + node.nodeSize;
+        }
+        const tableNode = yfmTableType(schema).create(
+            null,
+            yfmTableBodyType(schema).create(null, tRows),
+        );
+        slice = new Slice(Fragment.from(tableNode).append(slice.content.cut(bodiesSize)), 0, 0);
+    }
+    return slice;
+}

--- a/src/extensions/yfm/YfmTable/spec.ts
+++ b/src/extensions/yfm/YfmTable/spec.ts
@@ -10,10 +10,11 @@ export type YfmTableSpecOptions = {
 
 export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSpec> => ({
     [YfmTableNode.Table]: {
-        group: 'block',
+        group: 'block yfm-table',
         content: `${YfmTableNode.Body}`,
         isolating: true,
-        parseDOM: [{tag: 'table'}],
+        definingAsContext: true,
+        parseDOM: [{tag: 'table', priority: 200}],
         toDOM() {
             return ['table', 0];
         },
@@ -25,10 +26,14 @@ export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSp
     },
 
     [YfmTableNode.Body]: {
-        group: 'block',
+        group: 'block yfm-table',
         content: `${YfmTableNode.Row}+`,
         isolating: true,
-        parseDOM: [{tag: 'tbody'}],
+        definingAsContext: true,
+        parseDOM: [
+            {tag: 'tbody', priority: 200},
+            {tag: 'thead', priority: 200},
+        ],
         toDOM() {
             return ['tbody', 0];
         },
@@ -39,10 +44,11 @@ export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSp
     },
 
     [YfmTableNode.Row]: {
-        group: 'block',
+        group: 'block yfm-table',
         content: `${YfmTableNode.Cell}+`,
         isolating: true,
-        parseDOM: [{tag: 'tr'}],
+        definingAsContext: true,
+        parseDOM: [{tag: 'tr', priority: 200}],
         toDOM() {
             return ['tr', 0];
         },
@@ -54,10 +60,14 @@ export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSp
     },
 
     [YfmTableNode.Cell]: {
-        group: 'block',
+        group: 'block yfm-table',
         content: 'block+',
         isolating: true,
-        parseDOM: [{tag: 'td'}],
+        definingAsContext: true,
+        parseDOM: [
+            {tag: 'td', priority: 200},
+            {tag: 'th', priority: 200},
+        ],
         toDOM() {
             return ['td', 0];
         },

--- a/src/extensions/yfm/YfmTable/utils.ts
+++ b/src/extensions/yfm/YfmTable/utils.ts
@@ -1,3 +1,4 @@
+import type {Fragment, Node} from 'prosemirror-model';
 import {nodeTypeFactory} from '../../../utils/schema';
 import {YfmTableNode} from './const';
 
@@ -5,3 +6,11 @@ export const yfmTableType = nodeTypeFactory(YfmTableNode.Table);
 export const yfmTableBodyType = nodeTypeFactory(YfmTableNode.Body);
 export const yfmTableRowType = nodeTypeFactory(YfmTableNode.Row);
 export const yfmTableCellType = nodeTypeFactory(YfmTableNode.Cell);
+
+export function getContentAsArray(node: Node | Fragment) {
+    const content: {node: Node; offset: number}[] = [];
+    node.forEach((node, offset) => {
+        content.push({node, offset});
+    });
+    return content;
+}

--- a/tests/dispatch-event.ts
+++ b/tests/dispatch-event.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-implicit-globals */
+import type {EditorView} from 'prosemirror-view';
+import {DataTransferType as DTType} from '../src/extensions/behavior/Clipboard/utils';
+import {ClipboardEventMock, DataTransferMock} from './event-mock';
+
+export function dispatchPasteEvent(view: EditorView, data: {[K in DTType]?: string}): void;
+export function dispatchPasteEvent(view: EditorView, data: Record<string, string>): void {
+    const clipboardData = new DataTransferMock();
+    for (const [key, value] of Object.entries(data)) {
+        clipboardData.setData(key, value);
+    }
+    view.dispatchEvent(new ClipboardEventMock('paste', {clipboardData}));
+}

--- a/tests/event-mock.ts
+++ b/tests/event-mock.ts
@@ -1,0 +1,94 @@
+/** WARNING: This mock don't working with files */
+export class DataTransferMock implements DataTransfer {
+    #storage = new Map<string, string>();
+    #types = new Set<string>();
+
+    dropEffect: 'copy' | 'link' | 'none' | 'move' = 'none';
+    effectAllowed:
+        | 'copy'
+        | 'link'
+        | 'none'
+        | 'move'
+        | 'copyLink'
+        | 'copyMove'
+        | 'linkMove'
+        | 'all'
+        | 'uninitialized' = 'none';
+    readonly files: FileList = [] as unknown as FileList;
+
+    readonly items: DataTransferItemList = [] as unknown as DataTransferItemList;
+
+    get types(): readonly string[] {
+        return Array.from<string>(this.#types.values());
+    }
+
+    clearData(format?: string | undefined): void {
+        if (format) {
+            this.#types.delete(format);
+            this.#storage.delete(format);
+        } else {
+            this.#types.clear();
+            this.#storage.clear();
+        }
+    }
+
+    getData(format: string): string {
+        return this.#storage.get(format) ?? '';
+    }
+
+    setData(format: string, data: string): void {
+        this.#storage.set(format, data);
+        this.#types.add(format);
+    }
+
+    setDragImage(_image: Element, _x: number, _y: number): void {
+        throw new Error('Method setDragImage not implemented in DataTransferMock.');
+    }
+}
+
+export class ClipboardEventMock implements ClipboardEvent {
+    readonly clipboardData: DataTransfer | null;
+    readonly bubbles: boolean;
+    cancelBubble = false;
+    readonly cancelable: boolean;
+    readonly composed: boolean;
+    readonly currentTarget: EventTarget | null = null;
+    readonly defaultPrevented: boolean = false;
+    readonly eventPhase: number = 0;
+    readonly isTrusted: boolean = true;
+    readonly returnValue: boolean = false;
+    readonly srcElement: EventTarget | null = null;
+    readonly target: EventTarget | null = null;
+    readonly timeStamp: DOMHighResTimeStamp = Date.now();
+    readonly type: string;
+    readonly AT_TARGET: number = 0;
+    readonly BUBBLING_PHASE: number = 0;
+    readonly CAPTURING_PHASE: number = 0;
+    readonly NONE: number = 0;
+    constructor(type: string, eventInitDict?: ClipboardEventInit) {
+        this.type = type;
+        this.bubbles = eventInitDict?.bubbles ?? false;
+        this.composed = eventInitDict?.composed ?? false;
+        this.cancelable = eventInitDict?.cancelable ?? true;
+        this.clipboardData = eventInitDict?.clipboardData ?? null;
+    }
+    composedPath(): EventTarget[] {
+        return [];
+    }
+    initEvent(
+        _type: string,
+        _bubbles?: boolean | undefined,
+        _cancelable?: boolean | undefined,
+    ): void {
+        // throw new Error('Method not implemented.');
+    }
+    preventDefault(): void {
+        // throw new Error('Method not implemented.');
+    }
+    stopImmediatePropagation(): void {
+        // throw new Error('Method not implemented.');
+    }
+    stopPropagation(): void {
+        // throw new Error('Method not implemented.');
+    }
+}

--- a/tests/parse-dom.ts
+++ b/tests/parse-dom.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-implicit-globals */
+import type {Node, Schema} from 'prosemirror-model';
+import {EditorState} from 'prosemirror-state';
+import {EditorView} from 'prosemirror-view';
+import {dispatchPasteEvent} from './dispatch-event';
+
+export function parseDOM(schema: Schema, html: string, doc: Node): void {
+    const view = new EditorView(null, {state: EditorState.create({schema})});
+    dispatchPasteEvent(view, {'text/html': html});
+    expect(view.state.doc).toMatchNode(doc);
+}


### PR DESCRIPTION
Returned parsing of HTML from clipboard when pasting.
Added more `parseDOM` rules.
Create code block when paste from vscode