### PR TITLE
feat(YfmCut): don't open/close yfm-cut by clicking on the title

### DIFF
--- a/src/extensions/yfm/YfmCut/index.ts
+++ b/src/extensions/yfm/YfmCut/index.ts
@@ -9,6 +9,7 @@ import {fromYfm} from './fromYfm';
 import {getSpec, YfmCutSpecOptions} from './spec';
 import {createYfmCut, toYfmCut} from './actions/toYfmCut';
 import {backToCutTitle, exitFromCutTitle, liftEmptyBlockFromCut, removeCut} from './commands';
+import {YfmCutTitleNodeView} from './nodeviews/yfm-cut-title';
 
 const cutAction = 'toYfmCut';
 
@@ -43,6 +44,7 @@ export const YfmCut: ExtensionAuto<YfmCutOptions> = (builder, opts) => {
             fromYfm: {
                 tokenSpec: fromYfm[CutNode.CutTitle],
             },
+            view: () => (node) => new YfmCutTitleNodeView(node),
         }))
         .addNode(CutNode.CutContent, () => ({
             spec: spec[CutNode.CutContent],

--- a/src/extensions/yfm/YfmCut/nodeviews/yfm-cut-title.scss
+++ b/src/extensions/yfm/YfmCut/nodeviews/yfm-cut-title.scss
@@ -1,0 +1,3 @@
+.yfm-cut-title .ye-yfm-cut-title-inner {
+    cursor: text;
+}

--- a/src/extensions/yfm/YfmCut/nodeviews/yfm-cut-title.ts
+++ b/src/extensions/yfm/YfmCut/nodeviews/yfm-cut-title.ts
@@ -1,0 +1,31 @@
+import type {Node} from 'prosemirror-model';
+import type {NodeView} from 'prosemirror-view';
+
+import './yfm-cut-title.scss';
+
+export class YfmCutTitleNodeView implements NodeView {
+    readonly dom: HTMLElement;
+    readonly contentDOM: HTMLElement;
+
+    private node: Node;
+
+    constructor(node: Node) {
+        this.node = node;
+
+        this.dom = document.createElement('div');
+        this.dom.classList.add('yfm-cut-title');
+        this.dom.replaceChildren((this.contentDOM = document.createElement('div')));
+        this.contentDOM.classList.add('ye-yfm-cut-title-inner');
+        this.contentDOM.addEventListener('click', (e) => {
+            // ignore clicking on the title content
+            // you can open/close yfm-cut by clicking on the arrow icon
+            e.stopPropagation();
+        });
+    }
+
+    update(node: Node): boolean {
+        if (this.node.type !== node.type) return false;
+        this.node = node;
+        return true;
+    }
+}


### PR DESCRIPTION
Now you can open/close YfmCut by clicking on the arrow icon, but not on the title content