### PR TITLE
fix: blockquote button breaks when selection has 0 depth

### DIFF
--- a/src/extensions/markdown/Blockquote/commands.ts
+++ b/src/extensions/markdown/Blockquote/commands.ts
@@ -37,7 +37,7 @@ export const toggleQuote: Command = (state, dispatch) => {
     if (!isTextSelection(selection) || !selection.$cursor) return wrapIn(qType)(state, dispatch);
     const {$cursor} = selection;
     let {depth} = $cursor;
-    while (depth >= 0) {
+    while (depth > 0) {
         const node = $cursor.node(depth);
         const nodeSpec = node.type.spec;
         if (!nodeSpec.complex || nodeSpec.complex === 'root') {


### PR DESCRIPTION
there is a code below that breaks when selection has depth that equals to zero when you try to call ResolvedPos.before or ResolvedPos.after for that depth. because there is no sense to check whether there is a node before or after a doc node
