### PR TITLE
feat(Selection, Cursor)!: rewrite code for fake-paragraph behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17498,9 +17498,9 @@
       "integrity": "sha512-11hTMG4Qwqlux6Vwp/4m16mLDg6IwWb0/odsWXGtWvvRJo61SfG0RGYlA8H72vExmbnWpiXa7PNenZ6t12Rkqw=="
     },
     "prosemirror-view": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.26.2.tgz",
-      "integrity": "sha512-CGKw+GadkfSBEwRAJTHCEKJ4DlV6/3IhAdjpwGyZHUHtbP7jX4Ol4zmi7xa2c6GOabDlIJLYXJydoNYLX7lNeQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.30.0.tgz",
+      "integrity": "sha512-z6RXp2GFH8mk7+LWCGWvdpOIpf5o5UwIB6SiBiTFe6eA8H8qwFDW0EkiIfohlATHoSGXvlHtD+hfpAHdfO5fvQ==",
       "requires": {
         "prosemirror-model": "^1.16.0",
         "prosemirror-state": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prosemirror-state": "1.4.1",
     "prosemirror-transform": "1.6.0",
     "prosemirror-utils": "1.0.0-0",
-    "prosemirror-view": "1.26.2",
+    "prosemirror-view": "1.30.0",
     "react-use": "^17.3.2",
     "tslib": "^2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:prettier": "prettier --check \"{src,demo}/**/*.{js,jsx,ts,tsx,css,scss}\"",
     "test": "jest",
     "test:cov": "jest --coverage",
+    "test:watch": "jest --watchAll",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "repository": {

--- a/src/extensions/behavior/Clipboard/clipboard.ts
+++ b/src/extensions/behavior/Clipboard/clipboard.ts
@@ -36,7 +36,6 @@ export const clipboard = ({
 }: ClipboardPluginOptions) => {
     return new Plugin({
         props: {
-            // @ts-expect-error handleDOMEvents has broken types
             handleDOMEvents: {
                 copy(view, e) {
                     if (!e.clipboardData) return false;

--- a/src/extensions/behavior/Cursor/GapCursorSelection.ts
+++ b/src/extensions/behavior/Cursor/GapCursorSelection.ts
@@ -2,19 +2,42 @@ import {Selection} from 'prosemirror-state';
 import type {Node, ResolvedPos} from 'prosemirror-model';
 import type {Mapping} from 'prosemirror-transform';
 
+export function isGapCursorSelection<T>(selection: Selection): selection is GapCursorSelection<T> {
+    return selection instanceof GapCursorSelection;
+}
+
 // @ts-expect-error // TODO: implements toJSON
-export class GapCursorSelection extends Selection {
-    constructor(pos: ResolvedPos) {
-        super(pos, pos);
+export class GapCursorSelection<T = any> extends Selection {
+    #_$pos: ResolvedPos;
+
+    readonly meta?: T;
+
+    readonly selectionName = 'GapCursorSelection';
+
+    get $pos(): ResolvedPos {
+        return this.#_$pos;
+    }
+
+    get pos(): number {
+        return this.#_$pos.pos;
+    }
+
+    constructor($pos: ResolvedPos, params?: {meta?: T}) {
+        super($pos, $pos);
+        this.#_$pos = $pos;
+        this.meta = params?.meta;
     }
 
     eq(other: Selection): boolean {
-        return other instanceof GapCursorSelection && other.head === this.head;
+        return (
+            isGapCursorSelection(other) &&
+            this.pos === other.pos &&
+            this.$pos.doc.eq(other.$pos.doc)
+        );
     }
 
     map(doc: Node, mapping: Mapping): Selection {
         const $pos = doc.resolve(mapping.map(this.head));
-
         return Selection.near($pos);
     }
 }

--- a/src/extensions/behavior/Cursor/gapcursor.ts
+++ b/src/extensions/behavior/Cursor/gapcursor.ts
@@ -1,10 +1,11 @@
 import {DOMSerializer} from 'prosemirror-model';
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
-import {EditorState, NodeSelection, Plugin, PluginKey} from 'prosemirror-state';
+import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
 
+import {isNodeSelection} from '../../../utils/selection';
 import {pType} from '../../base/BaseSchema';
 import {createPlaceholder} from '../../behavior/Placeholder';
-import {GapCursorSelection} from './GapCursorSelection';
+import {isGapCursorSelection} from './GapCursorSelection';
 
 import './gapcursor.scss';
 
@@ -16,10 +17,8 @@ export const gapCursor = () =>
         state: {
             init: () => false,
             apply: (_tr, _pluginState, _oldState, newState) => {
-                return (
-                    newState.selection instanceof GapCursorSelection ||
-                    newState.selection instanceof NodeSelection
-                );
+                const sel = newState.selection;
+                return isGapCursorSelection(sel) || isNodeSelection(sel);
             },
         },
         view() {
@@ -33,7 +32,7 @@ export const gapCursor = () =>
         },
         props: {
             decorations: ({doc, selection}: EditorState) => {
-                if (selection instanceof GapCursorSelection) {
+                if (isGapCursorSelection(selection)) {
                     const position = selection.head;
 
                     return DecorationSet.create(doc, [

--- a/src/extensions/behavior/Selection/commands.test.ts
+++ b/src/extensions/behavior/Selection/commands.test.ts
@@ -1,0 +1,178 @@
+import type {Node} from 'prosemirror-model';
+import {TextSelection} from 'prosemirror-state';
+import {builders} from 'prosemirror-test-builder';
+
+import {ExtensionsManager} from '../../../core';
+import {BaseNode, BaseSchema} from '../../base/BaseSchema';
+import {Blockquote, blockquote} from '../../markdown/Blockquote';
+import {CodeBlock, codeBlockNodeName} from '../../markdown/CodeBlock';
+import {YfmTable, YfmTableNode} from '../../yfm/YfmTable';
+
+import {Direction, findFakeParaPosForTextSelection} from './commands';
+
+const {schema} = new ExtensionsManager({
+    extensions: (builder) =>
+        builder
+            .use(BaseSchema, {})
+            .use(Blockquote, {})
+            .use(CodeBlock, {})
+            .use(YfmTable, {})
+            .addNode('testnode', () => ({
+                spec: {content: `block*`, group: 'block', gapcursor: false},
+                fromYfm: {tokenSpec: {name: 'testnode', type: 'block', ignore: true}},
+                toYfm: () => {},
+            })),
+}).buildDeps();
+
+const {doc, p, bq, codeBlock, table, tbody, tr, td, testnode} = builders(schema, {
+    doc: {nodeType: BaseNode.Doc},
+    p: {nodeType: BaseNode.Paragraph},
+    bq: {nodeType: blockquote},
+    codeBlock: {nodeType: codeBlockNodeName},
+    table: {nodeType: YfmTableNode.Table},
+    tbody: {nodeType: YfmTableNode.Body},
+    tr: {nodeType: YfmTableNode.Row},
+    td: {nodeType: YfmTableNode.Cell},
+}) as PMTestBuilderResult<
+    'doc' | 'p' | 'bq' | 'codeBlock' | 'table' | 'tbody' | 'tr' | 'td' | 'testnode'
+>;
+
+function shouldFindPos(doc: Node, dir: Direction, selPos: number, fakePos: number) {
+    const sel = TextSelection.create(doc, selPos);
+    const $pos = findFakeParaPosForTextSelection(sel.$cursor!, dir);
+
+    expect($pos).toBeTruthy();
+    expect($pos!.pos).toBe(fakePos);
+}
+
+function shouldReturnNull(doc: Node, dir: Direction, selPos: number) {
+    const sel = TextSelection.create(doc, selPos);
+    const $pos = findFakeParaPosForTextSelection(sel.$cursor!, dir);
+
+    expect($pos).toBeNull();
+}
+
+describe('Selection arrow commands: findFakeParaPosForTextSelection', () => {
+    it.each(['before', 'after'] as const)(
+        'should not find fake paragraph position %s empty paragraph in doc',
+        (dir) => {
+            shouldReturnNull(doc(p()), dir, 1);
+        },
+    );
+
+    it.each(['before', 'after'] as const)(
+        'should not find fake paragraph position %s empty paragraph [2]',
+        (dir) => {
+            shouldReturnNull(doc(p(), p(), p()), dir, 3); // cursor in second paragraph
+        },
+    );
+
+    it.each([
+        ['before', 0],
+        ['after', 2],
+    ] as const)('should find fake paragraph position %s codeblock', (dir, fakePos) => {
+        shouldFindPos(doc(codeBlock()), dir, 1, fakePos);
+    });
+
+    it.each(['before', 'after'] as const)(
+        'should not find fake paragraph position %s codeblock ',
+        (dir) => {
+            shouldReturnNull(doc(p(), codeBlock(), p()), dir, 3); // cursor in codeblock
+        },
+    );
+
+    it.each([
+        ['before', 3, 2],
+        ['after', 1, 2],
+    ] as const)(
+        'should find fake paragraph position between code blocks [%s]',
+        (dir, selPos, fakePos) => {
+            shouldFindPos(doc(codeBlock(), codeBlock()), dir, selPos, fakePos);
+        },
+    );
+
+    it.each([
+        ['before', 0],
+        ['after', 4],
+    ] as const)('should find fake paragraph position %s block (blockquote)', (dir, fakePos) => {
+        shouldFindPos(doc(bq(p())), dir, 2, fakePos); // cursor in para in blockquote
+    });
+
+    it.each([
+        ['before', 6, 4],
+        ['after', 2, 4],
+    ] as const)(
+        'should find fake paragraph position between blocks (blockquotes) [%s]',
+        (dir, selPos, fakePos) => {
+            shouldFindPos(doc(bq(p()), bq(p())), dir, selPos, fakePos);
+        },
+    );
+
+    it.each([
+        ['before', 4], // cursor in second para
+        ['after', 2], // cursor in first para
+    ] as const)(
+        'should not find fake paragraph position beetween paragraphs in block (in blockquote) [%s]',
+        (dir, selPos) => {
+            shouldReturnNull(doc(bq(p(), p())), dir, selPos);
+        },
+    );
+
+    it.each([
+        ['before', 9, 4],
+        ['after', 31, 36],
+    ] as const)(
+        'should find fake paragraph position on edge of complex block (yfm-table) [%s]',
+        (dir, selPos, fakePos) => {
+            shouldFindPos(
+                doc(
+                    bq(p()),
+                    table(tbody(tr(td(p()), td(p()), td(p())), tr(td(p()), td(p()), td(p())))),
+                    bq(p()),
+                ),
+                dir,
+                selPos,
+                fakePos,
+            );
+        },
+    );
+
+    it.each([
+        ['before', 19],
+        ['after', 5],
+    ] as const)(
+        'should not find fake paragraph position inside of complex block (yfm-table) [%s]',
+        (dir, selPos) => {
+            shouldReturnNull(
+                doc(table(tbody(tr(td(p()), td(p()), td(p())), tr(td(p()), td(p()), td(p()))))),
+                dir,
+                selPos,
+            );
+        },
+    );
+
+    it.each([
+        ['before', 7],
+        ['after', 29],
+    ] as const)(
+        'should not find fake paragraph position on edge of complex block (yfm-table) with textblock [%s]',
+        (dir, selPos) => {
+            shouldReturnNull(
+                doc(
+                    p(),
+                    table(tbody(tr(td(p()), td(p()), td(p())), tr(td(p()), td(p()), td(p())))),
+                    p(),
+                ),
+                dir,
+                selPos,
+            );
+        },
+    );
+
+    it.each([
+        ['before', 3, 0],
+        ['after', 3, 6],
+    ] as const)('should skip nodes with `gapcursor: false` flag [%s]', (dir, selPos, fakePos) => {
+        shouldFindPos(doc(testnode(bq(p()))), dir, selPos, fakePos);
+    });
+});

--- a/src/extensions/behavior/Selection/commands.ts
+++ b/src/extensions/behavior/Selection/commands.ts
@@ -1,124 +1,167 @@
-import type {Node} from 'prosemirror-model';
-import {findChildren, findParentNodeClosestToPos} from 'prosemirror-utils';
-import {Command, EditorState, NodeSelection, TextSelection} from 'prosemirror-state';
+import {Node, ResolvedPos} from 'prosemirror-model';
+import type {Command, NodeSelection, Transaction} from 'prosemirror-state';
 
 import {isCodeBlock} from '../../../utils/nodes';
-import {GapCursorSelection} from '../../behavior/Cursor/GapCursorSelection';
-import {createFakeParagraphNear} from '../../../utils/selection';
+import {get$Cursor, isNodeSelection} from '../../../utils/selection';
 
-export {createFakeParagraphNear};
+import {GapCursorSelection, isGapCursorSelection} from '../Cursor/GapCursorSelection';
 
-export enum Direction {
-    up = 'up',
-    right = 'right',
-    left = 'left',
-    down = 'down',
+export type Direction = 'before' | 'after';
+type ArrowDirection = 'up' | 'right' | 'down' | 'left';
+
+type TextSelectionFinder = ($cursor: ResolvedPos, dir: Direction) => ResolvedPos | null;
+type NodeSelectionFinder = (selection: NodeSelection, dir: Direction) => ResolvedPos | null;
+type GapCursorSelectionFinder = (
+    selection: GapCursorSelection,
+    dir: Direction,
+) => ResolvedPos | null;
+
+type GapCursorMeta = {direction: Direction};
+
+const isUp = (dir: ArrowDirection) => dir === 'left' || dir === 'up';
+
+function isTextblock(node: Node): boolean {
+    return node.isTextblock && !isCodeBlock(node);
 }
 
-const isUp = (dir: Direction) => [Direction.up, Direction.left].includes(dir);
+function isEdgeTextblock($cursor: ResolvedPos, dir: Direction): boolean {
+    const index = $cursor.index($cursor.depth - 1);
+    if (dir === 'before') return index === 0;
+    if (dir === 'after') return index === $cursor.node($cursor.depth - 1).childCount - 1;
+    return false;
+}
 
-const findEdgeNode = (n: Node) =>
-    n.type.spec.complex === 'root' || // code block is exceptional
-    isCodeBlock(n);
+const findNextFakeParaPosForGapCursorSelection: GapCursorSelectionFinder = ({$pos}, dir) => {
+    return findFakeParaPosClosestToPos($pos, $pos.depth, dir);
+};
 
-const arrow =
-    (dir: Direction): Command =>
-    (state, dispatch) => {
-        const {selection} = state;
-        const pos = state.doc.resolve(selection.head);
+export const findFakeParaPosForNodeSelection: NodeSelectionFinder = (selection, dir) => {
+    const selectedNode = selection.node;
+    if (selectedNode.isInline || isTextblock(selectedNode)) return null;
 
-        if (selection instanceof TextSelection || selection instanceof GapCursorSelection) {
-            const parent = findParentNodeClosestToPos(pos, findEdgeNode);
+    const {$from} = selection;
+    const index = $from.index();
+    const parentNode = $from.parent;
+    if (dir === 'before') {
+        if (parentNode.firstChild === selectedNode || !isTextblock(parentNode.child(index - 1))) {
+            return $from;
+        }
+    } else if (dir === 'after') {
+        if (parentNode.lastChild === selectedNode || !isTextblock(parentNode.child(index + 1))) {
+            return selection.$to;
+        }
+    }
 
-            if (isUp(dir) && needParagraphBefore(state, dir)) {
-                return createFakeParagraphNear(Direction.up, parent)(state, dispatch);
-            }
-            if (!isUp(dir) && needParagraphAfter(state, dir)) {
-                return createFakeParagraphNear(Direction.down, parent)(state, dispatch);
-            }
+    return null;
+};
+
+export const findFakeParaPosForCodeBlock: TextSelectionFinder = ($cursor, dir) => {
+    if (!isCodeBlock($cursor.parent)) return null;
+
+    let foundPos = -1;
+    const index = $cursor.index($cursor.depth - 1);
+    const parent = $cursor.node($cursor.depth - 1);
+    if (dir === 'before') {
+        if (index === 0 || !isTextblock(parent.child(index - 1))) {
+            foundPos = $cursor.before();
+        }
+    } else if (dir === 'after') {
+        if (index === parent.childCount - 1 || !isTextblock(parent.child(index + 1))) {
+            foundPos = $cursor.after();
+        }
+    }
+
+    return foundPos !== -1 ? $cursor.doc.resolve(foundPos) : null;
+};
+
+export const findFakeParaPosForTextSelection: TextSelectionFinder = ($cursor, dir) => {
+    if ($cursor.parent.isInline) return null;
+
+    const $pos = findFakeParaPosForCodeBlock($cursor, dir);
+    if ($pos) return $pos;
+
+    if (!isEdgeTextblock($cursor, dir)) return null;
+
+    return findFakeParaPosClosestToPos($cursor, $cursor.depth - 1, dir);
+};
+
+function findFakeParaPosClosestToPos(
+    $pos: ResolvedPos,
+    depth: number,
+    dir: Direction,
+): ResolvedPos | null {
+    depth++;
+    while (--depth > 0) {
+        const node = $pos.node(depth);
+        const index = $pos.index(depth - 1);
+        const parent = $pos.node(depth - 1);
+
+        if (parent.type.spec.gapcursor === false) continue;
+
+        if (node.type.spec.complex === 'inner' || node.type.spec.complex === 'leaf') {
+            if (dir === 'before' && index === 0) continue;
+            if (dir === 'after' && index === parent.childCount - 1) continue;
+            return null;
         }
 
-        if (selection instanceof NodeSelection) {
-            if (selection.node.isInline) return false;
+        if (dir === 'before') {
+            if (index === 0 || !isTextblock(parent.child(index - 1))) {
+                return $pos.doc.resolve($pos.before(depth));
+            }
+        } else if (dir === 'after') {
+            if (index === parent.childCount - 1 || !isTextblock(parent.child(index + 1))) {
+                return $pos.doc.resolve($pos.after(depth));
+            }
+        }
+    }
+    return null;
+}
 
-            return createFakeParagraphNear(isUp(dir) ? Direction.up : Direction.down, {
-                pos: pos.pos - 1,
-                node: selection.$from.parent,
-            })(state, dispatch);
+const arrow =
+    (dir: ArrowDirection): Command =>
+    (state, dispatch, view) => {
+        const {selection} = state;
+        const direction: Direction = isUp(dir) ? 'before' : 'after';
+        let $pos: ResolvedPos | null = null;
+
+        if (isGapCursorSelection<GapCursorMeta>(selection)) {
+            if (selection.meta?.direction !== direction) {
+                return false;
+            }
+
+            // if gap selection is at start or end of doc
+            if (dir === 'up' && selection.pos === 0) return true;
+            if (dir === 'down' && selection.pos === state.doc.nodeSize - 2) return true;
+
+            $pos = findNextFakeParaPosForGapCursorSelection(selection, direction);
+        }
+
+        if (isNodeSelection(selection)) {
+            $pos = findFakeParaPosForNodeSelection(selection, direction);
+        }
+
+        const $cursor = get$Cursor(selection);
+        if ($cursor && view?.endOfTextblock(dir)) {
+            $pos = findFakeParaPosForTextSelection($cursor, direction);
+        }
+
+        if ($pos) {
+            dispatch?.(createFakeParagraph(state.tr, $pos, direction).scrollIntoView());
+            return true;
         }
 
         return false;
     };
 
-export const arrowLeft = arrow(Direction.left);
-export const arrowDown = arrow(Direction.down);
-export const arrowUp = arrow(Direction.up);
-export const arrowRight = arrow(Direction.right);
+export function createFakeParagraph(
+    tr: Transaction,
+    $pos: ResolvedPos,
+    direction: Direction,
+): Transaction {
+    return tr.setSelection(new GapCursorSelection<GapCursorMeta>($pos, {meta: {direction}}));
+}
 
-export const needParagraphBefore = (state: EditorState, dir: Direction) => {
-    if (!isUp(dir)) return false;
-
-    const {selection} = state;
-    const {$from} = selection;
-
-    const pos = state.doc.resolve(selection.head);
-
-    const disabledParent = findParentNodeClosestToPos(pos, (n) => n.type.spec.disableGapCursor);
-    if (disabledParent) {
-        return false;
-    }
-
-    const parent = findParentNodeClosestToPos(pos, findEdgeNode);
-
-    if (parent) {
-        if (state.doc.resolve(Math.max(parent.pos - 1, 0)).parent.type.name === 'paragraph') {
-            return false;
-        }
-
-        const firstTextBlock = findChildren(parent.node, (n) => n.isTextblock || n.isText)[0];
-
-        return (
-            parent.start === $from.pos - ($from.depth - parent.depth) ||
-            (dir === 'up' &&
-                $from.pos < parent.start + firstTextBlock.pos + firstTextBlock.node.nodeSize)
-        );
-    }
-
-    return false;
-};
-
-export const needParagraphAfter = (state: EditorState, dir: Direction) => {
-    if (isUp(dir)) return false;
-
-    const {selection} = state;
-    const {$from} = selection;
-
-    const pos = state.doc.resolve(selection.head);
-
-    const disabledParent = findParentNodeClosestToPos(pos, (n) => n.type.spec.disableGapCursor);
-
-    if (disabledParent) {
-        return false;
-    }
-
-    const parent = findParentNodeClosestToPos(pos, findEdgeNode);
-    if (parent) {
-        if (
-            state.doc.resolve(
-                Math.min(parent.pos + parent.node.nodeSize + 1, state.doc.nodeSize - 2),
-            ).parent.type.name === 'paragraph'
-        ) {
-            return false;
-        }
-
-        const children = findChildren(parent.node, (n) => n.isTextblock || n.isText);
-        const lastTextBlock = children[children.length - 1];
-
-        return (
-            parent.pos + parent.node.nodeSize === $from.pos + ($from.depth - parent.depth) + 1 ||
-            (dir === 'down' && $from.pos > parent.start + lastTextBlock.pos)
-        );
-    }
-
-    return false;
-};
+export const arrowLeft = arrow('left');
+export const arrowDown = arrow('down');
+export const arrowUp = arrow('up');
+export const arrowRight = arrow('right');

--- a/src/extensions/behavior/Selection/index.ts
+++ b/src/extensions/behavior/Selection/index.ts
@@ -1,8 +1,7 @@
 import type {ExtensionAuto} from '../../../core';
 import {selection} from './selection';
-import * as SelectionCommands from './commands';
 
-export {SelectionCommands};
+export {createFakeParagraph, findFakeParaPosForCodeBlock} from './commands';
 
 export const Selection: ExtensionAuto = (builder) => {
     builder.addPlugin(selection);

--- a/src/extensions/behavior/Selection/index.ts
+++ b/src/extensions/behavior/Selection/index.ts
@@ -1,7 +1,13 @@
 import type {ExtensionAuto} from '../../../core';
 import {selection} from './selection';
 
-export {createFakeParagraph, findFakeParaPosForCodeBlock} from './commands';
+export {
+    createFakeParagraph,
+    findFakeParaPosForNodeSelection,
+    findFakeParaPosForTextSelection,
+    findFakeParaPosForCodeBlock,
+    findFakeParaPosClosestToPos,
+} from './commands';
 
 export const Selection: ExtensionAuto = (builder) => {
     builder.addPlugin(selection);

--- a/src/extensions/markdown/Link/paste-plugin.ts
+++ b/src/extensions/markdown/Link/paste-plugin.ts
@@ -7,7 +7,6 @@ import {LinkAttr, linkType} from './index';
 export function linkPasteEnhance({parser}: ExtensionDeps) {
     return new Plugin({
         props: {
-            // @ts-expect-error handleDOMEvents has broken types
             handleDOMEvents: {
                 paste(view, e): boolean {
                     const {state, dispatch} = view;

--- a/src/extensions/markdown/Table/spec.ts
+++ b/src/extensions/markdown/Table/spec.ts
@@ -13,7 +13,6 @@ export const spec: Record<TableNode, NodeSpec> = {
         },
         selectable: true,
         allowSelection: true,
-        allowGapCursor: true,
         tableRole: TableRole.Table,
         complex: 'root',
     },
@@ -54,7 +53,6 @@ export const spec: Record<TableNode, NodeSpec> = {
         toDOM() {
             return ['tr', 0];
         },
-        allowGapCursor: false,
         tableRole: TableRole.Row,
         selectable: false,
         allowSelection: false,

--- a/src/extensions/yfm/YfmCut/spec.ts
+++ b/src/extensions/yfm/YfmCut/spec.ts
@@ -20,7 +20,6 @@ export const getSpec = (opts?: YfmCutSpecOptions): Record<CutNode, NodeSpec> => 
         toDOM(node) {
             return ['div', node.attrs, 0];
         },
-        allowGapCursor: true,
         selectable: true,
         allowSelection: true,
         defining: true,

--- a/src/extensions/yfm/YfmNote/spec.ts
+++ b/src/extensions/yfm/YfmNote/spec.ts
@@ -30,7 +30,6 @@ export const getSpec = (opts?: YfmNoteSpecOptions): Record<NoteNode, NodeSpec> =
         },
         selectable: true,
         allowSelection: true,
-        allowGapCursor: true,
         complex: 'root',
     },
 

--- a/src/extensions/yfm/YfmTable/commands/goToNextRow.ts
+++ b/src/extensions/yfm/YfmTable/commands/goToNextRow.ts
@@ -5,7 +5,6 @@ import {
     findParentTable,
     findParentTableCell,
 } from '../../../../table-utils/utils';
-import {createFakeParagraphNear} from '../../../../utils/selection';
 
 export function goToNextRow(dir: 'up' | 'down'): Command {
     return (state, dispatch, view) => {
@@ -37,9 +36,7 @@ export function goToNextRow(dir: 'up' | 'down'): Command {
         const newRowIndex = rowIndex + (dir === 'up' ? -1 : 1);
 
         if (newRowIndex < 0 || newRowIndex >= allRows.length) {
-            createFakeParagraphNear(dir, parentTable)(state, dispatch);
-
-            return true;
+            return false;
         }
 
         const newRow = allRows[newRowIndex];

--- a/src/extensions/yfm/YfmTable/spec.ts
+++ b/src/extensions/yfm/YfmTable/spec.ts
@@ -20,7 +20,6 @@ export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSp
         },
         selectable: true,
         allowSelection: true,
-        allowGapCursor: true,
         tableRole: TableRole.Table,
         complex: 'root',
     },
@@ -52,7 +51,6 @@ export const getSpec = (opts?: YfmTableSpecOptions): Record<YfmTableNode, NodeSp
         toDOM() {
             return ['tr', 0];
         },
-        allowGapCursor: false,
         tableRole: TableRole.Row,
         selectable: false,
         allowSelection: false,

--- a/src/extensions/yfm/YfmTabs/spec.ts
+++ b/src/extensions/yfm/YfmTabs/spec.ts
@@ -43,7 +43,6 @@ export const spec: Record<TabsNode, NodeSpec> = {
     },
 
     [TabsNode.Tabs]: {
-        allowGapCursor: true,
         attrs: {class: {default: 'unknown'}},
         content: 'yfm_tabs_list yfm_tab_panel+',
         group: 'block',
@@ -53,6 +52,7 @@ export const spec: Record<TabsNode, NodeSpec> = {
         },
         complex: 'root',
     },
+
     [TabsNode.TabsList]: {
         attrs: {class: {default: 'unknown'}, role: {default: 'unknown'}},
         content: 'yfm_tab*',

--- a/src/selection.d.ts
+++ b/src/selection.d.ts
@@ -1,4 +1,4 @@
-import prosemirrorState from 'prosemirror-state';
+import type prosemirrorState from 'prosemirror-state';
 
 declare module 'prosemirror-state' {
     class Selection extends prosemirrorState.Selection {

--- a/src/types/spec.ts
+++ b/src/types/spec.ts
@@ -15,6 +15,13 @@ declare module 'prosemirror-model' {
          */
         complex?: 'root' | 'inner' | 'leaf';
         escapeText?: boolean;
+
+        /**
+         * Set `false` to disable gapcursor selection inside this node.
+         *
+         * @default true
+         */
+        gapcursor?: boolean;
     }
 
     interface MarkSpec {

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,7 +1,5 @@
 import type {Node, NodeType, ResolvedPos} from 'prosemirror-model';
-import {Selection, TextSelection, NodeSelection, AllSelection, Command} from 'prosemirror-state';
-import type {NodeWithPos} from 'prosemirror-utils';
-import {GapCursorSelection} from '../extensions/behavior/Cursor/GapCursorSelection';
+import {Selection, TextSelection, NodeSelection, AllSelection} from 'prosemirror-state';
 
 NodeSelection.prototype.selectionName = 'NodeSelection';
 TextSelection.prototype.selectionName = 'TextSelection';
@@ -40,25 +38,3 @@ export const findSelectedNodeOfType = (nodeType: NodeType) => {
         return null;
     };
 };
-
-export const createFakeParagraphNear: (direction: 'up' | 'down', parent?: NodeWithPos) => Command =
-    (direction, parent) => (state, dispatch) => {
-        const paragraph = state.schema.nodes.paragraph;
-
-        if (!paragraph || !parent) {
-            return false;
-        }
-
-        const insertPos = direction === 'up' ? parent.pos : parent.pos + parent.node.nodeSize;
-
-        const tr = state.tr;
-        const sel = new GapCursorSelection(tr.doc.resolve(insertPos));
-
-        tr.setSelection(sel);
-
-        if (dispatch) {
-            dispatch(tr);
-        }
-
-        return true;
-    };


### PR DESCRIPTION
I rewrote the code that for the behavior with the fake paragraph. This fixed some bugs and improved the behavior in general.

1. Don't create fake paragraph near with textblocks.
2. Fixed error, that's occurred with node-selection and `after`-direction
3. Add _waterfall_ fake-paragraphs behaviour. For example, cursor in `doc -> blockquote -> yfm_cut -> yfm_note -> blockquote`. On first `down` press fake paragraph will be created in `yfm_note`, then in `yfm_cut`, then in `blockquote`, and then in `doc`