### PR TITLE
feat(Blockquote): support for joining the previous blockquote

### DIFF
--- a/src/extensions/markdown/Blockquote/commands.test.ts
+++ b/src/extensions/markdown/Blockquote/commands.test.ts
@@ -1,0 +1,134 @@
+import {Node} from 'prosemirror-model';
+import {EditorState, TextSelection, Transaction, Selection, Command} from 'prosemirror-state';
+import {builders} from 'prosemirror-test-builder';
+
+import {ExtensionsManager} from '../../../core';
+import {get$Cursor, isNodeSelection} from '../../../utils/selection';
+import {BaseNode, BaseSpecsPreset} from '../../base/specs';
+import {HtmlAttr, HtmlNode, Html} from '../Html';
+import {DeflistNode, DeflistSpecs} from '../Deflist/DeflistSpecs';
+
+import {blockquoteNodeName, BlockquoteSpecs} from './BlockquoteSpecs';
+import {joinPrevQuote} from './commands';
+
+const {schema} = new ExtensionsManager({
+    extensions: (builder) =>
+        builder.use(BaseSpecsPreset, {}).use(BlockquoteSpecs).use(Html).use(DeflistSpecs, {}),
+}).buildDeps();
+
+const {doc, p, bq, htmlBlock, dList, dTerm, dDesc} = builders(schema, {
+    doc: {nodeType: BaseNode.Doc},
+    p: {nodeType: BaseNode.Paragraph},
+    bq: {nodeType: blockquoteNodeName},
+    htmlBlock: {nodeType: HtmlNode.Block},
+    dList: {nodeType: DeflistNode.List},
+    dTerm: {nodeType: DeflistNode.Term},
+    dDesc: {nodeType: DeflistNode.Desc},
+}) as PMTestBuilderResult<'doc' | 'p' | 'bq' | 'htmlBlock', 'dList' | 'dTerm' | 'dDesc'>;
+
+function shouldDispatch(
+    cmd: Command,
+    init: {doc: Node; sel?: (doc: Node) => Selection},
+    expected: {doc: Node; sel?: (sel: Selection) => boolean},
+    onSuccess?: (tr: Transaction) => void,
+) {
+    const state = EditorState.create({
+        doc: init.doc,
+        selection: init.sel?.(init.doc),
+    });
+
+    let tr: Transaction;
+    const res = cmd(state, (tr_) => {
+        tr = tr_;
+    });
+
+    expect(res).toBe(true);
+    expect(tr!.doc).toMatchNode(expected.doc);
+    if (expected.sel) expect(expected.sel(tr!.selection)).toBe(true);
+
+    onSuccess?.(tr!);
+}
+
+describe('Blockqoute commands', () => {
+    describe('joinPrevQuote', () => {
+        const shouldDispatchWithCursorSelection = (
+            initDoc: Node,
+            initCursorSel: number,
+            expectDoc: Node,
+            expectCursor: number,
+        ) =>
+            shouldDispatch(
+                joinPrevQuote,
+                {doc: initDoc, sel: (doc) => TextSelection.create(doc, initCursorSel)},
+                {doc: expectDoc},
+                (tr) => expect(get$Cursor(tr.selection)?.pos).toBe(expectCursor),
+            );
+
+        const shouldDispatchWithNodeSelection = (
+            initDoc: Node,
+            initCursorSel: number,
+            expectDoc: Node,
+            expectNodeSel: number,
+        ) =>
+            shouldDispatch(
+                joinPrevQuote,
+                {doc: initDoc, sel: (doc) => TextSelection.create(doc, initCursorSel)},
+                {doc: expectDoc, sel: isNodeSelection},
+                (tr) => expect(tr.selection.from).toBe(expectNodeSel),
+            );
+
+        it('should join to textblock in quote', () => {
+            shouldDispatchWithCursorSelection(
+                doc(bq(p('para in blockqoute')), p('text')),
+                23, // at start of second paragraph
+                doc(bq(p('para in blockqoutetext'))),
+                20,
+            );
+        });
+
+        it('should join to textblock in nested quotes', () => {
+            shouldDispatchWithCursorSelection(
+                doc(bq(bq(bq(p('para in nested blockqoutes')))), p('text')),
+                35, // at start of second paragraph
+                doc(bq(bq(bq(p('para in nested blockqoutestext'))))),
+                30,
+            );
+        });
+
+        it('should join to last textblock in qoute', () => {
+            shouldDispatchWithCursorSelection(
+                doc(bq(p('first'), p('second')), p('third')),
+                18, // at start of third paragraph
+                doc(bq(p('first'), p('secondthird'))),
+                15,
+            );
+        });
+
+        it('should select last atom block', () => {
+            shouldDispatchWithNodeSelection(
+                doc(bq(htmlBlock({[HtmlAttr.Content]: '<div/>'})), p('para')),
+                4, // at start of para
+                doc(bq(htmlBlock({[HtmlAttr.Content]: '<div/>'})), p('para')),
+                1, // before html-block
+            );
+        });
+
+        it('should select last atom block and remove current empty textblock', () => {
+            shouldDispatchWithNodeSelection(
+                doc(bq(htmlBlock({[HtmlAttr.Content]: '<div/>'})), p('')),
+                4, // at start of para
+                doc(bq(htmlBlock({[HtmlAttr.Content]: '<div/>'}))),
+                1, // before html-block
+            );
+        });
+
+        it('should move current textblock to end of last non-qoute block', () => {
+            shouldDispatchWithCursorSelection(
+                doc(bq(dList(dTerm('Term'), dDesc(p('Definition')))), p('current')),
+                25, // at start of current paragraph
+                doc(bq(dList(dTerm('Term'), dDesc(p('Definition'), p('current'))))),
+                22, // at start of current paragraph
+            );
+        });
+    });
+});

--- a/src/extensions/markdown/Blockquote/index.ts
+++ b/src/extensions/markdown/Blockquote/index.ts
@@ -3,7 +3,7 @@ import type {NodeType} from 'prosemirror-model';
 import {wrappingInputRule} from 'prosemirror-inputrules';
 import {hasParentNodeOfType} from 'prosemirror-utils';
 import type {Action, ExtensionAuto} from '../../../core';
-import {selectQuoteBeforeCursor, liftFromQuote, toggleQuote} from './commands';
+import {liftFromQuote, toggleQuote, joinPrevQuote} from './commands';
 import {BlockquoteSpecs, blockquoteType} from './BlockquoteSpecs';
 
 export {blockquote, blockquoteNodeName, blockquoteType} from './const';
@@ -22,7 +22,7 @@ export const Blockquote: ExtensionAuto<BlockquoteOptions> = (builder, opts) => {
     }
 
     builder.addKeymap(() => ({
-        Backspace: chainCommands(liftFromQuote, selectQuoteBeforeCursor),
+        Backspace: chainCommands(liftFromQuote, joinPrevQuote),
     }));
 
     builder.addInputRules(({schema}) => ({rules: [blockQuoteRule(blockquoteType(schema))]}));

--- a/src/extensions/markdown/Html/index.ts
+++ b/src/extensions/markdown/Html/index.ts
@@ -5,7 +5,7 @@ import {fromYfm} from './fromYfm';
 import {spec} from './spec';
 import {toYfm} from './toYfm';
 
-export {HtmlNode} from './const';
+export {HtmlAttr, HtmlNode} from './const';
 
 export const Html: ExtensionAuto = (builder) => {
     if (builder.context.has('html') && builder.context.get('html') === false) {

--- a/src/extensions/yfm/YfmTable/paste.ts
+++ b/src/extensions/yfm/YfmTable/paste.ts
@@ -1,13 +1,14 @@
 import {Fragment, Node, Schema, Slice} from 'prosemirror-model';
-import {getContentAsArray, yfmTableBodyType, yfmTableType} from './utils';
+import {getChildrenOfNode} from '../../../utils/nodes';
+import {yfmTableBodyType, yfmTableType} from './utils';
 
 export function fixPastedTableBodies(slice: Slice, schema: Schema): Slice {
     if (slice.content.firstChild?.type === yfmTableBodyType(schema)) {
         const tRows: Node[] = [];
         let bodiesSize = 0;
-        for (const {node, offset} of getContentAsArray(slice.content)) {
+        for (const {node, offset} of getChildrenOfNode(slice.content)) {
             if (node.type !== yfmTableBodyType(schema)) break;
-            tRows.push(...getContentAsArray(node).map((item) => item.node));
+            tRows.push(...getChildrenOfNode(node).map((item) => item.node));
             bodiesSize = offset + node.nodeSize;
         }
         const tableNode = yfmTableType(schema).create(

--- a/src/extensions/yfm/YfmTable/utils.ts
+++ b/src/extensions/yfm/YfmTable/utils.ts
@@ -1,11 +1,1 @@
-import type {Fragment, Node} from 'prosemirror-model';
-
 export * from './YfmTableSpecs/utils';
-
-export function getContentAsArray(node: Node | Fragment) {
-    const content: {node: Node; offset: number}[] = [];
-    node.forEach((node, offset) => {
-        content.push({node, offset});
-    });
-    return content;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,6 @@ export {
     findSelectedNodeOfType,
 } from './utils/selection';
 export * from './table-utils';
+
+export type {NodeChild} from './utils/nodes';
+export {getChildrenOfNode, getLastChildOfNode} from './utils/nodes';

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -6,10 +6,7 @@ export function findFirstTextblockChild(
 ): {node: Node; offset: number} | null {
     if (parent instanceof Node && (!parent.isBlock || parent.isAtom)) return null;
 
-    const children: {node: Node; offset: number}[] = [];
-    parent.forEach((node, offset) => children.push({node, offset}));
-
-    for (const child of children) {
+    for (const child of getChildrenOfNode(parent)) {
         if (child.node.isTextblock) return child;
         const nestedTextBlockChild = findFirstTextblockChild(child.node);
         if (nestedTextBlockChild) {
@@ -47,4 +44,16 @@ export const isSelectableNode = (node: Node) => {
 
 export function isCodeBlock(node: Node): boolean {
     return node.isTextblock && Boolean(node.type.spec.code);
+}
+
+export type NodeChild = {node: Node; offset: number; index: number};
+export function getChildrenOfNode(node: Node | Fragment): NodeChild[] {
+    const children: NodeChild[] = [];
+    node.forEach((node, offset, index) => children.push({node, offset, index}));
+    return children;
+}
+
+export function getLastChildOfNode(node: Node | Fragment): NodeChild {
+    const children = getChildrenOfNode(node);
+    return children[children.length - 1];
 }


### PR DESCRIPTION
**Before**: if the cursor is at the beginning of the paragraph and before the current paragraph is a blockquote, then when you press backspace, a NodeSelection was created on the quote

**Now**: if the cursor is at the beginning of the paragraph and before the current paragraph is a blockquote, then when you press backspace, current paragpraph joining with content inside blockquote