### PR TITLE
fix(CodeBlock): fix parsing and serialization of code and fence blocks

### DIFF
--- a/src/core/markdown/MarkdownParser.ts
+++ b/src/core/markdown/MarkdownParser.ts
@@ -183,7 +183,11 @@ export class MarkdownParser implements Parser {
 
         if (tokenSpec.noCloseToken) {
             this.openNode(schemaSpec, attrs);
-            this.addText(yfmToken.content);
+            let {content} = yfmToken;
+            if (tokenSpec.prepareContent) {
+                content = tokenSpec.prepareContent(content);
+            }
+            this.addText(content);
             this.closeNode();
 
             return;

--- a/src/core/types/parser.ts
+++ b/src/core/types/parser.ts
@@ -20,4 +20,6 @@ export interface ParserToken {
     // То есть контент лежит в поле content токена, а не между открывающим и закрывающим токенами.
     noCloseToken?: boolean;
     ignore?: boolean;
+    /** only for tokens with type=block */
+    prepareContent?: (content: string) => string;
 }

--- a/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlock.test.ts
@@ -22,29 +22,23 @@ describe('CodeBlock extension', () => {
     it('should parse a code block', () =>
         same(
             'Some code:\n\n```\nHere it is\n```\n\nPara',
-            doc(
-                p('Some code:'),
-                cb({[codeBlockLangAttr]: ''}, schema.text('Here it is\n')),
-                p('Para'),
-            ),
+            doc(p('Some code:'), cb({[codeBlockLangAttr]: ''}, 'Here it is'), p('Para')),
         ));
 
     it('parses an intended code block', () =>
         parse(
             'Some code:\n\n    Here it is\n\nPara',
-            doc(p('Some code:'), cb('Here it is\n'), p('Para')),
+            doc(p('Some code:'), cb('Here it is'), p('Para')),
         ));
 
     it('should parse a fenced code block with info string', () =>
         same(
             'foo\n\n```javascript\n1\n```',
-            doc(
-                p('foo'),
-                schema.node(codeBlockNodeName, {[codeBlockLangAttr]: 'javascript'}, [
-                    schema.text('1\n'),
-                ]),
-            ),
+            doc(p('foo'), cb({[codeBlockLangAttr]: 'javascript'}, '1')),
         ));
+
+    it('should parse a fenced code block with multiple new lines at the end', () =>
+        same('```\nsome code\n\n\n\n```', doc(cb({[codeBlockLangAttr]: ''}, 'some code\n\n\n'))));
 
     // TODO: parsed: doc(paragraph("code\nblock"))
     it.skip('should parse html - pre tag', () => {

--- a/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
+++ b/src/extensions/markdown/CodeBlock/CodeBlockSpecs/index.ts
@@ -39,12 +39,14 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 name: codeBlockNodeName,
                 type: 'block',
                 noCloseToken: true,
+                prepareContent: removeNewLineAtEnd, // content of code blocks contains extra \n at the end
             },
         },
         toYfm: (state, node) => {
             state.write('```' + (node.attrs[codeBlockLangAttr] || '') + '\n');
             state.text(node.textContent, false);
-            state.ensureNewLine();
+            // Add a newline to the current content before adding closing marker
+            state.write('\n');
             state.write('```');
             state.closeBlock(node);
         },
@@ -59,6 +61,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
                 type: 'block',
                 noCloseToken: true,
                 getAttrs: (tok) => ({[codeBlockLangAttr]: tok.info || ''}),
+                prepareContent: removeNewLineAtEnd, // content of fence blocks contains extra \n at the end
             },
         },
         toYfm: () => {
@@ -66,3 +69,7 @@ export const CodeBlockSpecs: ExtensionAuto<CodeBlockSpecsOptions> = (builder, op
         },
     }));
 };
+
+function removeNewLineAtEnd(content: string): string {
+    return content.endsWith('\n') ? content.slice(0, content.length - 1) : content;
+}


### PR DESCRIPTION
1. Remove extra new line at the end of content of code and fence blocks
2. Always add new line to node.textContent of codeblock when serializing