### PR TITLE
fix: escape whitespaces within superscript and subscript

### DIFF
--- a/src/core/markdown/MarkdownSerializer.js
+++ b/src/core/markdown/MarkdownSerializer.js
@@ -79,6 +79,8 @@ export class MarkdownSerializerState {
         this.noAutoBlank = false;
         /** @type {Boolean|undefined} */
         this.isAutolink = undefined;
+        /** @type {Boolean} */
+        this.escapeWhitespace = false;
         // :: Object
         // The options passed to the serializer.
         //   tightLists:: ?bool
@@ -162,7 +164,10 @@ export class MarkdownSerializerState {
         for (let i = 0; i < lines.length; i++) {
             const startOfLine = this.atBlank() || this.closed;
             this.write();
-            this.out += escape !== false ? this.esc(lines[i], startOfLine) : lines[i];
+            let text = lines[i];
+            if (escape !== false) text = this.esc(text, startOfLine)
+            if (this.escapeWhitespace) text = this.escWhitespace(text);
+            this.out += text
             if (i != lines.length - 1) this.out += '\n';
         }
     }
@@ -295,6 +300,10 @@ export class MarkdownSerializerState {
         str = str.replace(/[`\^+*\\\|~\[\]\{\}<>\$]/g, '\\$&');
         if (startOfLine) str = str.replace(/^[:#\-*+>]/, '\\$&').replace(/^(\s*\d+)\./, '$1\\.');
         return str;
+    }
+
+    escWhitespace(str) {
+        return str.replace(/ /g, '\\ ');
     }
 
     quote(str) {

--- a/src/extensions/markdown/Subscript/Subscript.test.ts
+++ b/src/extensions/markdown/Subscript/Subscript.test.ts
@@ -26,4 +26,11 @@ describe('Subscript extension', () => {
     it('should parse html - sub tag', () => {
         parseDOM(schema, '<p><sub>subscript</sub></p>', doc(p(s('subscript'))));
     });
+
+    it('should escape whitespaces', () => {
+        same(
+            'Ok, hello~w\\ o\\ r\\ l\\ d~! This world is beautiful!',
+            doc(p('Ok, hello', s('w o r l d'), '! This world is beautiful!')),
+        );
+    });
 });

--- a/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
+++ b/src/extensions/markdown/Subscript/SubscriptSpecs/index.ts
@@ -18,7 +18,18 @@ export const SubscriptSpecs: ExtensionAuto = (builder) => {
                     return ['sub'];
                 },
             },
-            toYfm: {open: '~', close: '~', mixable: false, expelEnclosingWhitespace: true},
+            toYfm: {
+                open: (state) => {
+                    state.escapeWhitespace = true;
+                    return '~';
+                },
+                close: (state) => {
+                    state.escapeWhitespace = false;
+                    return '~';
+                },
+                mixable: false,
+                expelEnclosingWhitespace: true,
+            },
             fromYfm: {tokenSpec: {name: subscriptMarkName, type: 'mark'}},
         }));
 };

--- a/src/extensions/markdown/Superscript/Superscript.test.ts
+++ b/src/extensions/markdown/Superscript/Superscript.test.ts
@@ -26,4 +26,11 @@ describe('Superscript extension', () => {
     it('should parse html - sup tag', () => {
         parseDOM(schema, '<p><sup>superscript</sup></p>', doc(p(s('superscript'))));
     });
+
+    it('should escape whitespaces', () => {
+        same(
+            'Ok, hello^w\\ o\\ r\\ l\\ d^! This world is beautiful!',
+            doc(p('Ok, hello', s('w o r l d'), '! This world is beautiful!')),
+        );
+    });
 });

--- a/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
+++ b/src/extensions/markdown/Superscript/SuperscriptSpecs/index.ts
@@ -18,7 +18,18 @@ export const SuperscriptSpecs: ExtensionAuto = (builder) => {
                     return ['sup'];
                 },
             },
-            toYfm: {open: '^', close: '^', mixable: true, expelEnclosingWhitespace: true},
+            toYfm: {
+                open: (state) => {
+                    state.escapeWhitespace = true;
+                    return '^';
+                },
+                close: (state) => {
+                    state.escapeWhitespace = false;
+                    return '^';
+                },
+                mixable: true,
+                expelEnclosingWhitespace: true,
+            },
             fromYfm: {tokenSpec: {name: superscriptMarkName, type: 'mark'}},
         }));
 };


### PR DESCRIPTION
`markdown-it-sup` and `markdown-it-sub` is based on [pandoc](https://pandoc.org/MANUAL.html#superscripts-and-subscripts) definition:

> The text between `^...^` or `~...~` may not contain spaces or newlines.
> ...
> if you want the letter P with ‘a cat’ in subscripts, use `P~a\ cat~`, not `P~a cat~`.