### PR TITLE
feat: add package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,40 @@
     "type": "git",
     "url": "https://github.com/yandex-cloud/yfm-editor"
   },
+  "exports": {
+    ".": {
+      "types": "./build/esm/index.d.ts",
+      "require": "./build/cjs/index.js",
+      "import": "./build/esm/index.js"
+    },
+    "./specs": {
+      "types": "./build/esm/extensions/specs.d.ts",
+      "require": "./build/cjs/extensions/specs.js",
+      "import": "./build/esm/extensions/specs.js"
+    },
+    "./pm/*": {
+      "types": "./build/esm/pm/*",
+      "require": "./build/cjs/pm/*",
+      "import": "./build/esm/pm/*"
+    },
+    "./styles/*": "./build/esm/styles/*"
+  },
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "types": "build/esm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "index.d.ts": [
+        "./build/esm/index.d.ts"
+      ],
+      "specs": [
+        "./build/esm/extensions/specs.d.ts"
+      ],
+      "pm/*": [
+        "./build/esm/pm/*"
+      ]
+    }
+  },
   "files": [
     "build"
   ],

--- a/src/extensions/behavior/ReactRenderer/index.ts
+++ b/src/extensions/behavior/ReactRenderer/index.ts
@@ -10,7 +10,7 @@ import {
     RenderStorageItemEventMap,
 } from './types';
 
-export type {RendererItem} from './types';
+export type {RendererItem, RenderStorage} from './types';
 export {Renderer as ReactRendererComponent} from './react';
 export type {RendererProps as ReactRendererComponentProps} from './react';
 

--- a/src/pm/commands.ts
+++ b/src/pm/commands.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-commands';

--- a/src/pm/history.ts
+++ b/src/pm/history.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-history';

--- a/src/pm/inputrules.ts
+++ b/src/pm/inputrules.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-inputrules';

--- a/src/pm/keymap.ts
+++ b/src/pm/keymap.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-keymap';

--- a/src/pm/model.ts
+++ b/src/pm/model.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-model';

--- a/src/pm/readme.md
+++ b/src/pm/readme.md
@@ -1,0 +1,16 @@
+## PM submodule
+
+### Re-exports prosemirror core modules:
+
+- [prosemirror-commands](https://github.com/ProseMirror/prosemirror-commands)
+- [prosemirror-history](https://github.com/ProseMirror/prosemirror-history)
+- [prosemirror-inputrules](https://github.com/ProseMirror/prosemirror-inputrules)
+- [prosemirror-keymap](https://github.com/ProseMirror/prosemirror-keymap)
+- [prosemirror-model](https://github.com/ProseMirror/prosemirror-model)
+- [prosemirror-state](https://github.com/ProseMirror/prosemirror-state)
+- [prosemirror-transform](https://github.com/ProseMirror/prosemirror-transform)
+- [prosemirror-view](https://github.com/ProseMirror/prosemirror-view)
+
+### Also some other modules:
+
+- [prosemirror-utils](https://github.com/atlassian/prosemirror-utils)

--- a/src/pm/state.ts
+++ b/src/pm/state.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-state';

--- a/src/pm/transform.ts
+++ b/src/pm/transform.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-transform';

--- a/src/pm/utils.ts
+++ b/src/pm/utils.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-utils';

--- a/src/pm/view.ts
+++ b/src/pm/view.ts
@@ -1,0 +1,1 @@
+export * from 'prosemirror-view';

--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -1,0 +1,1 @@
+@use '../extensions/yfm/Color/colors';


### PR DESCRIPTION
Adds `exports` and `typesVersions` to `package.json`.
Also adds `/pm` submodule, that re-export `prosemirror` modules