### PR TITLE
fix(deps): add markdown-it-attrs to deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/is-number": "^7.0.1",
         "@types/markdown-it": "^12.2.3",
         "is-number": "^7.0.0",
+        "markdown-it-attrs": "4.1.4",
         "markdown-it-color": "^2.1.1",
         "markdown-it-ins": "^3.0.1",
         "markdown-it-mark": "^3.0.1",
@@ -83,8 +84,8 @@
         "typescript": "^4.5.2"
       },
       "peerDependencies": {
-        "@diplodoc/transform": "^4.5.0",
         "@diplodoc/latex-extension": "^1.0.3",
+        "@diplodoc/transform": "^4.5.0",
         "@gravity-ui/components": "^2.0.0",
         "@gravity-ui/uikit": "^5.0.0",
         "katex": "^0.16.9",
@@ -8483,8 +8484,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -19014,7 +19014,6 @@
       "version": "0.16.9",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
       "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
-      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -19031,7 +19030,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">= 12"
@@ -19229,7 +19227,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -19510,7 +19507,6 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
       "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -19526,7 +19522,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.4.tgz",
       "integrity": "sha512-53Zfv8PTb6rlVFDlD106xcZHKBSsRZKJ2IW/rTxEJBEVbVaoxaNsmRkG0HXfbHl2SK8kaxZ2QKqdthWy/QBwmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -19590,7 +19585,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -19739,8 +19733,7 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -25774,8 +25767,7 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/is-number": "^7.0.1",
     "@types/markdown-it": "^12.2.3",
     "is-number": "^7.0.0",
+    "markdown-it-attrs": "4.1.4",
     "markdown-it-color": "^2.1.1",
     "markdown-it-ins": "^3.0.1",
     "markdown-it-mark": "^3.0.1",
@@ -167,8 +168,8 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "@diplodoc/transform": "^4.5.0",
     "@diplodoc/latex-extension": "^1.0.3",
+    "@diplodoc/transform": "^4.5.0",
     "@gravity-ui/components": "^2.0.0",
     "@gravity-ui/uikit": "^5.0.0",
     "katex": "^0.16.9",


### PR DESCRIPTION
`markdown-it-attrs` is in deps in `@diplodoc/transform`

But we use attrs plugin directly in _core_, so it should be in deps