### PR TITLE
feat(Checkbox): improve checkbox insertion

### DIFF
--- a/src/utils/inputrules.ts
+++ b/src/utils/inputrules.ts
@@ -2,7 +2,7 @@ import {InputRule} from 'prosemirror-inputrules';
 import {Fragment, Mark, MarkType, Node} from 'prosemirror-model';
 import {EditorState, TextSelection} from 'prosemirror-state';
 
-import {codeType} from '../extensions';
+import {codeType} from '../extensions/markdown/specs';
 import {isFunction} from '../lodash';
 import {isMarkActive} from '../utils/marks';
 // TODO: remove explicit import from code extension


### PR DESCRIPTION
New behavior of inserting checkbox:
- Disabled:
  - when selecting any text
  - when cursor inside complex textblock (exclude checkboxes)
  - selection type is some other then TextSelection or NodeSelection
- If cursor is in paragraph: replace current paragraph with checkbox with contents of paragraph
- If node selection or if cursor is in another textblock or checkbox: insert new checkbox after current node, and move cursor inside new checkbox