### PR TITLE
fix(Link): ascape parentheses in link url

### DIFF
--- a/src/extensions/markdown/Link/Link.test.ts
+++ b/src/extensions/markdown/Link/Link.test.ts
@@ -70,4 +70,16 @@ describe('Link extension', () => {
             'https://example.com/+_file/#~anchor',
         );
     });
+
+    it('should escape parentheses in url', () =>
+        same(
+            '[parentheses](https://example.com/example=?qwe\\(asd)',
+            doc(p(a({[LinkAttr.Href]: 'https://example.com/example=?qwe(asd'}, 'parentheses'))),
+        ));
+
+    it('should escape parentheses in url', () =>
+        same(
+            '[parentheses2](https://example.com/example=?qwe\\(asd\\)\\))',
+            doc(p(a({[LinkAttr.Href]: 'https://example.com/example=?qwe(asd))'}, 'parentheses2'))),
+        ));
 });

--- a/src/extensions/markdown/Link/LinkSpecs/index.ts
+++ b/src/extensions/markdown/Link/LinkSpecs/index.ts
@@ -58,7 +58,7 @@ export const LinkSpecs: ExtensionAuto = (builder) => {
                 state.isAutolink = undefined;
                 return (
                     '](' +
-                    mark.attrs[LinkAttr.Href] +
+                    escapeParenthesesInUrl(mark.attrs[LinkAttr.Href]) +
                     (mark.attrs[LinkAttr.Title]
                         ? ' ' + state.quote(mark.attrs[LinkAttr.Title])
                         : '') +
@@ -96,4 +96,8 @@ function isPlainURL(link: Mark, parent: Fragment, index: number, side: number) {
     const next = parent.child(index + (side < 0 ? -2 : 1));
 
     return !link.isInSet(next.marks);
+}
+
+function escapeParenthesesInUrl(url: string): string {
+    return url.replaceAll(/\(|\)/g, (p) => '\\' + p);
 }


### PR DESCRIPTION
Markdown-it incorrectly parses links with unbalanced parentheses in URLs.
This is fixed by escaping the parentheses.